### PR TITLE
Add CMA-ES planner

### DIFF
--- a/examples/particle.py
+++ b/examples/particle.py
@@ -4,7 +4,7 @@ import mujoco
 import numpy as np
 
 from hydrax import ROOT
-from hydrax.algs import MPPI, PredictiveSampling
+from hydrax.algs import CMAES, MPPI, PredictiveSampling
 from hydrax.mpc import run_interactive
 from hydrax.tasks.particle import Particle
 
@@ -24,8 +24,11 @@ if len(sys.argv) == 1 or sys.argv[1] == "ps":
 elif sys.argv[1] == "mppi":
     print("Running MPPI")
     ctrl = MPPI(task, num_samples=16, noise_level=0.3, temperature=0.01)
+elif sys.argv[1] == "cmaes":
+    print("Running CMA-ES")
+    ctrl = CMAES(task, num_samples=128, elite_ratio=0.5)
 else:
-    print("Usage: python particle.py [ps|mppi]")
+    print("Usage: python particle.py [ps|mppi|cmaes]")
     sys.exit(1)
 
 # Define the model used for simulation

--- a/hydrax/algs/__init__.py
+++ b/hydrax/algs/__init__.py
@@ -1,4 +1,5 @@
+from .cma_es import CMAES
 from .mppi import MPPI
 from .predictive_sampling import PredictiveSampling
 
-__all__ = ["MPPI", "PredictiveSampling"]
+__all__ = ["MPPI", "PredictiveSampling", "CMAES"]

--- a/hydrax/algs/cma_es.py
+++ b/hydrax/algs/cma_es.py
@@ -1,0 +1,99 @@
+from typing import Tuple
+
+import evosax
+import jax
+import jax.numpy as jnp
+from flax.struct import dataclass
+
+from hydrax.alg_base import SamplingBasedController, Trajectory
+from hydrax.task_base import Task
+
+
+@dataclass
+class CMAESParams:
+    """Policy parameters for CMA-ES.
+
+    Attributes:
+        controls: The latest control sequence, U = [u₀, u₁, ..., ].
+        opt_state: The state of the CMA-ES optimizer (covariance, etc.).
+        rng: The pseudo-random number generator key.
+    """
+
+    controls: jax.Array
+    opt_state: evosax.strategies.cma_es.EvoState
+    rng: jax.Array
+
+
+class CMAES(SamplingBasedController):
+    """Covariance Matrix Adaptation Evolution Strategy (CMA-ES) controller."""
+
+    def __init__(self, task: Task, num_samples: int, elite_ratio: float = 0.5):
+        """Initialize the controller.
+
+        Args:
+            task: The dynamics and cost for the system we want to control.
+            num_samples: The number of control tapes to sample.
+            elite_ratio: The ratio of top-performing samples to keep.
+        """
+        super().__init__(task)
+
+        self.strategy = evosax.CMA_ES(
+            popsize=num_samples,
+            num_dims=task.model.nu * (task.planning_horizon - 1),
+            elite_ratio=elite_ratio,
+        )
+
+        # TODO: consider exposing these evolution strategy parameters
+        self.es_params = self.strategy.default_params
+
+    def init_params(self, seed: int = 0) -> CMAESParams:
+        """Initialize the policy parameters."""
+        rng = jax.random.key(seed)
+        rng, init_rng = jax.random.split(rng)
+        controls = jnp.zeros(
+            (self.task.planning_horizon - 1, self.task.model.nu)
+        )
+        opt_state = self.strategy.initialize(init_rng, self.es_params)
+        return CMAESParams(controls=controls, opt_state=opt_state, rng=rng)
+
+    def sample_controls(
+        self, params: CMAESParams
+    ) -> Tuple[jax.Array, CMAESParams]:
+        """Sample control sequences from the proposal distribution."""
+        rng, sample_rng = jax.random.split(params.rng)
+        x, opt_state = self.strategy.ask(
+            sample_rng, params.opt_state, self.es_params
+        )
+
+        # evosax works with vectors of decision variables, so we reshape U to
+        # [batch_size, horizon - 1, nu].
+        controls = jnp.reshape(
+            x,
+            (
+                self.strategy.popsize,
+                self.task.planning_horizon - 1,
+                self.task.model.nu,
+            ),
+        )
+
+        return controls, params.replace(opt_state=opt_state, rng=rng)
+
+    def update_params(
+        self, params: CMAESParams, rollouts: Trajectory
+    ) -> CMAESParams:
+        """Update the policy parameters based on the rollouts."""
+        costs = jnp.sum(rollouts.costs, axis=1)
+        x = jnp.reshape(rollouts.controls, (self.strategy.popsize, -1))
+        opt_state = self.strategy.tell(
+            x, costs, params.opt_state, self.es_params
+        )
+        best_controls = opt_state.best_member.reshape(
+            (self.task.planning_horizon - 1, self.task.model.nu)
+        )
+        return params.replace(controls=best_controls, opt_state=opt_state)
+
+    def get_action(self, params: CMAESParams, t: float) -> jax.Array:
+        """Get the control action for the current time step, zero order hold."""
+        idx_float = t / self.task.dt  # zero order hold
+        idx = jnp.floor(idx_float).astype(jnp.int32)
+        return params.controls[idx]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "matplotlib>=3.8.3",
     "mujoco>=3.2.3",
     "mujoco-mjx>=3.2.3",
+    "evosax>=0.1.6",
 ]
 
 [tool.ruff]
@@ -79,3 +80,6 @@ docstring-code-line-length = "dynamic"
 testpaths = [
     "tests",
 ]
+
+[tool.setuptools]
+packages = ["hydrax"]

--- a/tests/test_cma_es.py
+++ b/tests/test_cma_es.py
@@ -1,0 +1,85 @@
+import jax
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+from mujoco import mjx
+
+from hydrax.algs.cma_es import CMAES
+from hydrax.tasks.pendulum import Pendulum
+
+
+def test_cmaes() -> None:
+    """Test the CMAES algorithm."""
+    task = Pendulum()
+    ctrl = CMAES(task, num_samples=32)
+
+    # Initialize the policy parameters
+    params = ctrl.init_params()
+    assert params.opt_state.C.shape == (19, 19)
+    assert params.opt_state.weights.shape == (32,)
+
+    # Sample control sequences from the policy
+    controls, params = ctrl.sample_controls(params)
+    assert controls.shape == (32, 19, 1)
+
+    # Roll out the control sequences
+    state = mjx.make_data(task.model)
+    rollouts = ctrl.eval_rollouts(state, controls)
+    assert rollouts.costs.shape == (32, 20)
+
+    # Update the policy parameters
+    params = ctrl.update_params(params, rollouts)
+    assert params.controls.shape == (19, 1)
+    assert jnp.all(params.controls != jnp.zeros((19, 1)))
+    assert params.opt_state.best_fitness > 0.0
+
+
+def test_open_loop() -> None:
+    """Use CMA-ES for open-loop optimization."""
+    # Task and optimizer setup
+    task = Pendulum()
+    opt = CMAES(task, num_samples=32, elite_ratio=0.1)
+    jit_opt = jax.jit(opt.optimize)
+
+    # Initialize the system state and policy parameters
+    state = mjx.make_data(task.model)
+    params = opt.init_params()
+
+    for _ in range(100):
+        # Do an optimization step
+        params, _ = jit_opt(state, params)
+
+    # Pick the best rollout
+    best_cost = params.opt_state.best_fitness
+    best_ctrl = params.controls
+    final_rollout = jax.jit(opt.eval_rollouts)(state, best_ctrl[None])
+    assert jnp.allclose(best_cost, jnp.sum(final_rollout.costs[0]))
+
+    if __name__ == "__main__":
+        # Plot the solution
+        _, ax = plt.subplots(3, 1, sharex=True)
+        times = jnp.arange(task.planning_horizon) * task.dt
+
+        ax[0].plot(times, final_rollout.observations[0, :, 0])
+        ax[0].set_ylabel(r"$\theta$")
+
+        ax[1].plot(times, final_rollout.observations[0, :, 1])
+        ax[1].set_ylabel(r"$\dot{\theta}$")
+
+        ax[2].step(times[0:-1], final_rollout.controls[0], where="post")
+        ax[2].axhline(-1.0, color="black", linestyle="--")
+        ax[2].axhline(1.0, color="black", linestyle="--")
+        ax[2].set_ylabel("u")
+        ax[2].set_xlabel("Time (s)")
+
+        time_samples = jnp.linspace(0, times[-1], 100)
+        controls = jax.vmap(opt.get_action, in_axes=(None, 0))(
+            params, time_samples
+        )
+        ax[2].plot(time_samples, controls, color="gray", alpha=0.5)
+
+        plt.show()
+
+
+if __name__ == "__main__":
+    test_cmaes()
+    test_open_loop()


### PR DESCRIPTION
Adds the CMA-ES planner based on [evosax](https://github.com/RobertTLange/evosax/tree/main?tab=readme-ov-file).

This doesn't work very well - it tends to get stuck if the goal changes - but provides an interesting case study in how tools for open-loop optimization aren't always the best for predictive control.