### PR TITLE
Domain randomization

### DIFF
--- a/examples/cube.py
+++ b/examples/cube.py
@@ -22,18 +22,37 @@ task = CubeRotation()
 # Set the controller based on command-line arguments
 if len(sys.argv) == 1 or sys.argv[1] == "ps":
     print("Running predictive sampling")
-    ctrl = PredictiveSampling(task, num_samples=1024, noise_level=0.2)
+    ctrl = PredictiveSampling(
+        task, num_samples=128, noise_level=0.2, num_randomizations=8
+    )
 elif sys.argv[1] == "mppi":
     print("Running MPPI")
-    ctrl = MPPI(task, num_samples=1024, noise_level=0.2, temperature=0.001)
+    ctrl = MPPI(
+        task,
+        num_samples=128,
+        noise_level=0.2,
+        temperature=0.001,
+        num_randomizations=8,
+    )
 elif sys.argv[1] == "cem":
     print("Running CEM")
     ctrl = CEM(
-        task, num_samples=1024, num_elites=5, sigma_start=0.5, sigma_min=0.5
+        task,
+        num_samples=128,
+        num_elites=5,
+        sigma_start=0.5,
+        sigma_min=0.5,
+        num_randomizations=8,
     )
 elif sys.argv[1] == "cmaes":
     print("Running CMA-ES")
-    ctrl = Evosax(task, evosax.Sep_CMA_ES, num_samples=1024, elite_ratio=0.5)
+    ctrl = Evosax(
+        task,
+        evosax.Sep_CMA_ES,
+        num_samples=128,
+        elite_ratio=0.5,
+        num_randomizations=8,
+    )
 else:
     print("Usage: python cube.py [ps|mppi|cem|cmaes]")
     sys.exit(1)

--- a/examples/particle.py
+++ b/examples/particle.py
@@ -21,7 +21,9 @@ task = Particle()
 # Set the controller based on command-line arguments
 if len(sys.argv) == 1 or sys.argv[1] == "ps":
     print("Running predictive sampling")
-    ctrl = PredictiveSampling(task, num_samples=16, noise_level=0.1)
+    ctrl = PredictiveSampling(
+        task, num_samples=16, noise_level=0.1, num_randomizations=1
+    )
 
 elif sys.argv[1] == "mppi":
     print("Running MPPI")

--- a/hydrax/alg_base.py
+++ b/hydrax/alg_base.py
@@ -50,12 +50,9 @@ class SamplingBasedController(ABC):
         rng, subrng = jax.random.split(rng)
         subrngs = jax.random.split(subrng, num_randomizations)
         randomizations = jax.vmap(self.task.domain_randomize_model)(subrngs)
-
-        # TODO: don't randomize if num_randomizations == 1
-        # or alternatively, always have the first model be the original
         self.model = self.task.model.tree_replace(randomizations)
 
-        # Keep track of which elements of the model have domain randomization
+        # Keep track of which elements of the model have randomization
         self.randomized_axes = jax.tree.map(lambda x: None, self.task.model)
         self.randomized_axes = self.randomized_axes.tree_replace(
             {key: 0 for key in randomizations.keys()}

--- a/hydrax/alg_base.py
+++ b/hydrax/alg_base.py
@@ -112,7 +112,7 @@ class SamplingBasedController(ABC):
             x: mjx.Data, u: jax.Array
         ) -> Tuple[mjx.Data, Tuple[jax.Array, jax.Array]]:
             """Compute the cost and observation, then advance the state."""
-            x = mjx.forward(model, x)  # compute site positions TODO: drop this?
+            x = mjx.forward(model, x)  # compute site positions
             cost = self.task.dt * self.task.running_cost(x, u)
             obs = self.task.get_obs(x)
             sites = self.task.get_trace_sites(x)

--- a/hydrax/alg_base.py
+++ b/hydrax/alg_base.py
@@ -34,13 +34,32 @@ class Trajectory:
 class SamplingBasedController(ABC):
     """An abstract sampling-based MPC algorithm interface."""
 
-    def __init__(self, task: Task):
+    def __init__(self, task: Task, num_randomizations: int, seed: int):
         """Initialize the MPC controller.
 
         Args:
             task: The task instance defining the dynamics and costs.
+            num_randomizations: The number of domain randomizations to use.
+            seed: The random seed for domain randomization.
         """
         self.task = task
+        self.num_randomizations = num_randomizations
+
+        # Make the randomized models
+        rng = jax.random.key(seed)
+        rng, subrng = jax.random.split(rng)
+        subrngs = jax.random.split(subrng, num_randomizations)
+        randomizations = jax.vmap(self.task.domain_randomize_model)(subrngs)
+
+        # TODO: don't randomize if num_randomizations == 1
+        # or alternatively, always have the first model be the original
+        self.model = self.task.model.tree_replace(randomizations)
+
+        # Keep track of which elements of the model have domain randomization
+        self.randomized_axes = jax.tree.map(lambda x: None, self.task.model)
+        self.randomized_axes = self.randomized_axes.tree_replace(
+            {key: 0 for key in randomizations.keys()}
+        )
 
     def optimize(self, state: mjx.Data, params: Any) -> Tuple[Any, Trajectory]:
         """Perform an optimization step to update the policy parameters.
@@ -53,17 +72,35 @@ class SamplingBasedController(ABC):
             Updated policy parameters
             Rollouts used to update the parameters
         """
+        # Sample random control sequences
         controls, params = self.sample_controls(params)
         controls = jnp.clip(controls, self.task.u_min, self.task.u_max)
-        rollouts = self.eval_rollouts(state, controls)
+
+        # Set the initial state for each rollout
+        rng, state_rng = jax.random.split(params.rng)
+        states = self.task.domain_randomize_data(
+            state, state_rng, self.num_randomizations
+        )
+        params = params.replace(rng=rng)
+
+        # Apply the control sequences, parallelized over both rollouts and
+        # domain randomizations.
+        rollouts = jax.vmap(
+            self.eval_rollouts, in_axes=(self.randomized_axes, 0, None)
+        )(self.model, states, controls)
+
+        # Update the policy parameters based on the rollout costs
         params = self.update_params(params, rollouts)
         return params, rollouts
 
-    @partial(jax.vmap, in_axes=(None, None, 0))
-    def eval_rollouts(self, state: mjx.Data, controls: jax.Array) -> Trajectory:
+    @partial(jax.vmap, in_axes=(None, None, None, 0))
+    def eval_rollouts(
+        self, model: mjx.Model, state: mjx.Data, controls: jax.Array
+    ) -> Trajectory:
         """Rollout control sequences (in parallel) and compute the costs.
 
         Args:
+            model: The mujoco dynamics model to use.
             state: The initial state x₀.
             controls: The control sequences, size (num rollouts, horizon - 1).
 
@@ -75,7 +112,7 @@ class SamplingBasedController(ABC):
             x: mjx.Data, u: jax.Array
         ) -> Tuple[mjx.Data, Tuple[jax.Array, jax.Array]]:
             """Compute the cost and observation, then advance the state."""
-            x = mjx.forward(self.task.model, x)  # compute site positions
+            x = mjx.forward(model, x)  # compute site positions TODO: drop this?
             cost = self.task.dt * self.task.running_cost(x, u)
             obs = self.task.get_obs(x)
             sites = self.task.get_trace_sites(x)
@@ -84,7 +121,7 @@ class SamplingBasedController(ABC):
             x = jax.lax.fori_loop(
                 0,
                 self.task.sim_steps_per_control_step,
-                lambda _, x: mjx.step(self.task.model, x),
+                lambda _, x: mjx.step(model, x),
                 x.replace(ctrl=u),
             )
 

--- a/hydrax/algs/cem.py
+++ b/hydrax/algs/cem.py
@@ -33,6 +33,8 @@ class CEM(SamplingBasedController):
         num_elites: int,
         sigma_start: float,
         sigma_min: float,
+        num_randomizations: int = 1,
+        seed: int = 0,
     ):
         """Initialize the controller.
 
@@ -42,8 +44,10 @@ class CEM(SamplingBasedController):
             num_elites: The number of elite samples to keep at each iteration.
             sigma_start: The initial standard deviation for the controls.
             sigma_min: The minimum standard deviation for the controls.
+            num_randomizations: The number of domain randomizations to use.
+            seed: The random seed for domain randomization.
         """
-        super().__init__(task)
+        super().__init__(task, num_randomizations, seed)
         self.num_samples = num_samples
         self.sigma_min = sigma_min
         self.sigma_start = sigma_start
@@ -74,17 +78,17 @@ class CEM(SamplingBasedController):
         self, params: CEMParams, rollouts: Trajectory
     ) -> CEMParams:
         """Update the mean with an exponentially weighted average."""
-        costs = jnp.sum(rollouts.costs, axis=1)
+        controls = rollouts.controls[0]  # identical over randomizations
+        costs = jnp.mean(rollouts.costs, axis=0)  # avg. over randomizations
+        costs = jnp.sum(costs, axis=1)  # sum over time steps
 
         # Sort the costs and get the indices of the elites.
         indices = jnp.argsort(costs)
         elites = indices[: self.num_elites]
 
         # The new proposal distribution is a Gaussian fit to the elites.
-        mean = jnp.mean(rollouts.controls[elites], axis=0)
-        cov = jnp.maximum(
-            jnp.std(rollouts.controls[elites], axis=0), self.sigma_min
-        )
+        mean = jnp.mean(controls[elites], axis=0)
+        cov = jnp.maximum(jnp.std(controls[elites], axis=0), self.sigma_min)
 
         return params.replace(mean=mean, cov=cov)
 

--- a/hydrax/algs/evosax.py
+++ b/hydrax/algs/evosax.py
@@ -41,6 +41,8 @@ class Evosax(SamplingBasedController):
         optimizer: evosax.Strategy,
         num_samples: int,
         es_params: EvoParams = None,
+        num_randomizations: int = 1,
+        seed: int = 0,
         **kwargs,
     ):
         """Initialize the controller.
@@ -50,9 +52,11 @@ class Evosax(SamplingBasedController):
             optimizer: The evosax optimizer to use.
             num_samples: The number of control tapes to sample.
             es_params: The parameters for the evosax optimizer.
+            num_randomizations: The number of domain randomizations to use.
+            seed: The random seed for domain randomization.
             **kwargs: Additional keyword arguments for the optimizer.
         """
-        super().__init__(task)
+        super().__init__(task, num_randomizations, seed)
 
         self.strategy = optimizer(
             popsize=num_samples,
@@ -100,14 +104,17 @@ class Evosax(SamplingBasedController):
         self, params: EvosaxParams, rollouts: Trajectory
     ) -> EvosaxParams:
         """Update the policy parameters based on the rollouts."""
-        costs = jnp.sum(rollouts.costs, axis=1)
-        x = jnp.reshape(rollouts.controls, (self.strategy.popsize, -1))
+        controls = rollouts.controls[0]  # identical over randomizations
+        costs = jnp.mean(rollouts.costs, axis=0)  # avg. over randomizations
+
+        costs = jnp.sum(costs, axis=1)  # sum over time steps
+        x = jnp.reshape(controls, (self.strategy.popsize, -1))
         opt_state = self.strategy.tell(
             x, costs, params.opt_state, self.es_params
         )
 
         best_idx = jnp.argmin(costs)
-        best_controls = rollouts.controls[best_idx]
+        best_controls = controls[best_idx]
 
         # By default, opt_state stores the best member ever, rather than the
         # best member from the current generation. We want to just use the best

--- a/hydrax/algs/predictive_sampling.py
+++ b/hydrax/algs/predictive_sampling.py
@@ -24,15 +24,24 @@ class PSParams:
 class PredictiveSampling(SamplingBasedController):
     """A simple implementation of https://arxiv.org/abs/2212.00541."""
 
-    def __init__(self, task: Task, num_samples: int, noise_level: float):
+    def __init__(
+        self,
+        task: Task,
+        num_samples: int,
+        noise_level: float,
+        num_randomizations: int = 1,
+        seed: int = 0,
+    ):
         """Initialize the controller.
 
         Args:
             task: The dynamics and cost for the system we want to control.
             num_samples: The number of control tapes to sample.
             noise_level: The scale of Gaussian noise to add to sampled controls.
+            num_randomizations: The number of domain randomizations to use.
+            seed: The random seed for domain randomization
         """
-        super().__init__(task)
+        super().__init__(task, num_randomizations, seed)
         self.noise_level = noise_level
         self.num_samples = num_samples
 
@@ -62,9 +71,10 @@ class PredictiveSampling(SamplingBasedController):
 
     def update_params(self, params: PSParams, rollouts: Trajectory) -> PSParams:
         """Update the policy parameters by choosing the lowest-cost rollout."""
-        costs = jnp.sum(rollouts.costs, axis=1)
+        costs = jnp.mean(rollouts.costs, axis=0)  # avg. over randomizations
+        costs = jnp.sum(costs, axis=1)  # sum over time steps
         best_idx = jnp.argmin(costs)
-        mean = rollouts.controls[best_idx]
+        mean = rollouts.controls[0, best_idx]
         return params.replace(mean=mean)
 
     def get_action(self, params: PSParams, t: float) -> jax.Array:

--- a/hydrax/algs/predictive_sampling.py
+++ b/hydrax/algs/predictive_sampling.py
@@ -72,9 +72,10 @@ class PredictiveSampling(SamplingBasedController):
     def update_params(self, params: PSParams, rollouts: Trajectory) -> PSParams:
         """Update the policy parameters by choosing the lowest-cost rollout."""
         costs = jnp.mean(rollouts.costs, axis=0)  # avg. over randomizations
+        controls = rollouts.controls[0]  # identical over randomizations
         costs = jnp.sum(costs, axis=1)  # sum over time steps
         best_idx = jnp.argmin(costs)
-        mean = rollouts.controls[0, best_idx]
+        mean = controls[best_idx]
         return params.replace(mean=mean)
 
     def get_action(self, params: PSParams, t: float) -> jax.Array:

--- a/hydrax/mpc.py
+++ b/hydrax/mpc.py
@@ -128,8 +128,8 @@ def run_interactive(
                                 viewer.user_scn.geoms[ii],
                                 mujoco.mjtGeom.mjGEOM_LINE,
                                 trace_width,
-                                rollouts.trace_sites[i, j, k],
-                                rollouts.trace_sites[i, j + 1, k],
+                                rollouts.trace_sites[0, i, j, k],
+                                rollouts.trace_sites[0, i, j + 1, k],
                             )
                             ii += 1
 

--- a/hydrax/tasks/cube.py
+++ b/hydrax/tasks/cube.py
@@ -67,3 +67,13 @@ class CubeRotation(Task):
         """The terminal cost ϕ(x_T)."""
         position_err = self._get_cube_position_err(state)
         return 100 * jnp.sum(jnp.square(position_err))
+
+    def domain_randomize_data(
+        self, data: mjx.Data, rng: jax.Array, n: int
+    ) -> mjx.Data:
+        """Randomly shift the measured configurations."""
+        batch_data = jax.vmap(lambda _, x: x, in_axes=(0, None))(
+            jnp.arange(n), data
+        )
+        shift = 0.005 * jax.random.normal(rng, (n, self.model.nq))
+        return batch_data.tree_replace({"qpos": data.qpos + shift})

--- a/hydrax/tasks/particle.py
+++ b/hydrax/tasks/particle.py
@@ -49,3 +49,13 @@ class Particle(Task):
         new_gains = self.model.actuator_gainprm[:, 0] * multiplier
         new_gains = self.model.actuator_gainprm.at[:, 0].set(new_gains)
         return {"actuator_gainprm": new_gains}
+
+    def domain_randomize_data(
+        self, data: mjx.Data, rng: jax.Array, n: int
+    ) -> mjx.Data:
+        """Randomly shift the measured particle position."""
+        batch_data = jax.vmap(lambda _, x: x, in_axes=(0, None))(
+            jnp.arange(n), data
+        )
+        shift = jax.random.uniform(rng, (n, 2), minval=-0.01, maxval=0.01)
+        return batch_data.tree_replace({"qpos": data.qpos + shift})

--- a/hydrax/tasks/particle.py
+++ b/hydrax/tasks/particle.py
@@ -1,3 +1,5 @@
+from typing import Dict
+
 import jax
 import jax.numpy as jnp
 import mujoco
@@ -38,3 +40,12 @@ class Particle(Task):
         )
         velocity_cost = jnp.sum(jnp.square(state.qvel))
         return 5.0 * position_cost + 0.1 * velocity_cost
+
+    def domain_randomize_model(self, rng: jax.Array) -> Dict[str, jax.Array]:
+        """Randomly perturb the actuator gains."""
+        multiplier = jax.random.uniform(
+            rng, self.model.actuator_gainprm[:, 0].shape, minval=0.9, maxval=1.1
+        )
+        new_gains = self.model.actuator_gainprm[:, 0] * multiplier
+        new_gains = self.model.actuator_gainprm.at[:, 0].set(new_gains)
+        return {"actuator_gainprm": new_gains}

--- a/tests/test_cem.py
+++ b/tests/test_cem.py
@@ -25,7 +25,9 @@ def test_open_loop() -> None:
         params, _ = jit_opt(state, params)
 
     # Roll out the solution, check that it's good enough
-    final_rollout = jax.jit(opt.eval_rollouts)(state, params.mean[None])
+    final_rollout = jax.jit(opt.eval_rollouts)(
+        task.model, state, params.mean[None]
+    )
     total_cost = jnp.sum(final_rollout.costs[0])
     assert total_cost <= 9.0
     assert jnp.all(params.cov >= opt.sigma_min)

--- a/tests/test_dr.py
+++ b/tests/test_dr.py
@@ -6,15 +6,32 @@ import mujoco
 from mujoco import mjx
 
 from hydrax import ROOT
+from hydrax.algs import PredictiveSampling
+from hydrax.tasks.particle import Particle
 
 
 def domain_randomize(model: mjx.Model, rng: jax.Array) -> Dict[str, jax.Array]:
-    """Generate randomized friction parameters."""
+    """Generate randomized model parameters."""
+    rng, friction_rng, actuator_rng = jax.random.split(rng, 3)
+
+    # Randomize friction
     new_frictions = jax.random.uniform(
-        rng, model.geom_friction[:, 0].shape, minval=0.1, maxval=2.0
+        friction_rng, model.geom_friction[:, 0].shape, minval=0.1, maxval=2.0
     )
     new_frictions = model.geom_friction.at[:, 0].set(new_frictions)
-    return {"geom_friction": new_frictions}
+
+    new_gains = (
+        jax.random.uniform(
+            actuator_rng,
+            model.actuator_gainprm[:, 0].shape,
+            minval=0.1,
+            maxval=2.0,
+        )
+        + model.actuator_gainprm[:, 0]
+    )
+    new_gains = model.actuator_gainprm.at[:, 0].set(new_gains)
+
+    return {"geom_friction": new_frictions, "actuator_gainprm": new_gains}
 
 
 def apply_randomization(
@@ -43,22 +60,24 @@ def test_domain_randomization() -> None:
     model = mjx.put_model(mj_model)
 
     # Randomize multiple models at once
+    num_randomizations = 3
     rng, subrng = jax.random.split(rng)
     randomization = jax.vmap(domain_randomize, in_axes=(None, 0))(
-        model, jax.random.split(subrng, 10)
+        model, jax.random.split(subrng, num_randomizations)
     )
     batch_model, in_axes = apply_randomization(model, randomization)
 
-    assert batch_model.geom_friction.shape[0] == 10
+    assert batch_model.geom_friction.shape[0] == num_randomizations
     assert batch_model.geom_friction.shape[1:] == model.geom_friction.shape
 
     # Step all the randomized models
     data = mjx.make_data(model)
+    data = data.tree_replace({"ctrl": jnp.ones(model.nu)})
     next_data = mjx.step(model, data)
     print(next_data.qpos.shape)
 
     batch_data = jax.vmap(lambda _, x: x, in_axes=(0, None))(
-        jnp.arange(10), data
+        jnp.arange(num_randomizations), data
     )
 
     next_batch_data = jax.vmap(mjx.step, in_axes=(in_axes, 0))(
@@ -67,6 +86,39 @@ def test_domain_randomization() -> None:
     print(batch_data.qpos.shape)
     print(next_batch_data.qpos.shape)
 
+    print(next_batch_data.qpos)
+
+
+def test_opt() -> None:
+    """Test optimization with domain randomization for the particle."""
+    task = Particle()
+    ctrl = PredictiveSampling(
+        task, num_samples=10, noise_level=0.1, num_randomizations=3
+    )
+    params = ctrl.init_params()
+
+    # Create a random initial state
+    state = mjx.make_data(task.model)
+    state = state.replace(mocap_pos=jnp.array([[0.5, 0.5, 0.0]]))
+    assert state.qpos.shape == (2,)
+
+    # Run an optimization step
+    params, rollouts = ctrl.optimize(state, params)
+
+    # Check the rollout shapes. Should be
+    # (randomizations, samples, timestep, ...)
+    assert rollouts.costs.shape == (3, 11, 5)
+    assert rollouts.controls.shape == (3, 11, 4, 2)
+    assert rollouts.observations.shape == (3, 11, 5, 4)
+
+    # Check the updated parameters
+    assert params.mean.shape == (4, 2)
+
+    print(params)
+
+    print(params.mean.shape)
+
 
 if __name__ == "__main__":
-    test_domain_randomization()
+    # test_domain_randomization()
+    test_opt()

--- a/tests/test_dr.py
+++ b/tests/test_dr.py
@@ -1,0 +1,72 @@
+from typing import Dict, Tuple
+
+import jax
+import jax.numpy as jnp
+import mujoco
+from mujoco import mjx
+
+from hydrax import ROOT
+
+
+def domain_randomize(model: mjx.Model, rng: jax.Array) -> Dict[str, jax.Array]:
+    """Generate randomized friction parameters."""
+    new_frictions = jax.random.uniform(
+        rng, model.geom_friction[:, 0].shape, minval=0.1, maxval=2.0
+    )
+    new_frictions = model.geom_friction.at[:, 0].set(new_frictions)
+    return {"geom_friction": new_frictions}
+
+
+def apply_randomization(
+    model: mjx.Model, randomization: Dict[str, jax.Array]
+) -> Tuple[mjx.Model, mjx.Model]:
+    """Apply a randomization to a model.
+
+    Return both the randomized model and a pytree with the randomized axes.
+    """
+    new_model = model.tree_replace(randomization)
+
+    in_axes = jax.tree.map(lambda x: None, model)
+    in_axes = in_axes.tree_replace(
+        {key: 0 for key in randomization.keys()},
+    )
+
+    return new_model, in_axes
+
+
+def test_domain_randomization() -> None:
+    """Smoke test for domain randomization."""
+    rng = jax.random.key(0)
+
+    # Load a model
+    mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/particle/scene.xml")
+    model = mjx.put_model(mj_model)
+
+    # Randomize multiple models at once
+    rng, subrng = jax.random.split(rng)
+    randomization = jax.vmap(domain_randomize, in_axes=(None, 0))(
+        model, jax.random.split(subrng, 10)
+    )
+    batch_model, in_axes = apply_randomization(model, randomization)
+
+    assert batch_model.geom_friction.shape[0] == 10
+    assert batch_model.geom_friction.shape[1:] == model.geom_friction.shape
+
+    # Step all the randomized models
+    data = mjx.make_data(model)
+    next_data = mjx.step(model, data)
+    print(next_data.qpos.shape)
+
+    batch_data = jax.vmap(lambda _, x: x, in_axes=(0, None))(
+        jnp.arange(10), data
+    )
+
+    next_batch_data = jax.vmap(mjx.step, in_axes=(in_axes, 0))(
+        batch_model, batch_data
+    )
+    print(batch_data.qpos.shape)
+    print(next_batch_data.qpos.shape)
+
+
+if __name__ == "__main__":
+    test_domain_randomization()

--- a/tests/test_dr.py
+++ b/tests/test_dr.py
@@ -1,92 +1,28 @@
-from typing import Dict, Tuple
-
-import jax
 import jax.numpy as jnp
-import mujoco
 from mujoco import mjx
 
-from hydrax import ROOT
 from hydrax.algs import PredictiveSampling
 from hydrax.tasks.particle import Particle
 
 
-def domain_randomize(model: mjx.Model, rng: jax.Array) -> Dict[str, jax.Array]:
-    """Generate randomized model parameters."""
-    rng, friction_rng, actuator_rng = jax.random.split(rng, 3)
-
-    # Randomize friction
-    new_frictions = jax.random.uniform(
-        friction_rng, model.geom_friction[:, 0].shape, minval=0.1, maxval=2.0
-    )
-    new_frictions = model.geom_friction.at[:, 0].set(new_frictions)
-
-    new_gains = (
-        jax.random.uniform(
-            actuator_rng,
-            model.actuator_gainprm[:, 0].shape,
-            minval=0.1,
-            maxval=2.0,
-        )
-        + model.actuator_gainprm[:, 0]
-    )
-    new_gains = model.actuator_gainprm.at[:, 0].set(new_gains)
-
-    return {"geom_friction": new_frictions, "actuator_gainprm": new_gains}
-
-
-def apply_randomization(
-    model: mjx.Model, randomization: Dict[str, jax.Array]
-) -> Tuple[mjx.Model, mjx.Model]:
-    """Apply a randomization to a model.
-
-    Return both the randomized model and a pytree with the randomized axes.
-    """
-    new_model = model.tree_replace(randomization)
-
-    in_axes = jax.tree.map(lambda x: None, model)
-    in_axes = in_axes.tree_replace(
-        {key: 0 for key in randomization.keys()},
-    )
-
-    return new_model, in_axes
-
-
 def test_domain_randomization() -> None:
-    """Smoke test for domain randomization."""
-    rng = jax.random.key(0)
-
-    # Load a model
-    mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/particle/scene.xml")
-    model = mjx.put_model(mj_model)
-
-    # Randomize multiple models at once
-    num_randomizations = 3
-    rng, subrng = jax.random.split(rng)
-    randomization = jax.vmap(domain_randomize, in_axes=(None, 0))(
-        model, jax.random.split(subrng, num_randomizations)
+    """Test basic domain randomization utilities."""
+    task = Particle()
+    ctrl1 = PredictiveSampling(
+        task, num_samples=10, noise_level=0.1, num_randomizations=1
     )
-    batch_model, in_axes = apply_randomization(model, randomization)
-
-    assert batch_model.geom_friction.shape[0] == num_randomizations
-    assert batch_model.geom_friction.shape[1:] == model.geom_friction.shape
-
-    # Step all the randomized models
-    data = mjx.make_data(model)
-    data = data.tree_replace({"ctrl": jnp.ones(model.nu)})
-    next_data = mjx.step(model, data)
-    print(next_data.qpos.shape)
-
-    batch_data = jax.vmap(lambda _, x: x, in_axes=(0, None))(
-        jnp.arange(num_randomizations), data
+    ctrl2 = PredictiveSampling(
+        task, num_samples=10, noise_level=0.1, num_randomizations=2
     )
 
-    next_batch_data = jax.vmap(mjx.step, in_axes=(in_axes, 0))(
-        batch_model, batch_data
-    )
-    print(batch_data.qpos.shape)
-    print(next_batch_data.qpos.shape)
+    # The models should have different numbers of randomizations
+    assert ctrl1.model.actuator_gainprm.shape[0] == 1
+    assert ctrl2.model.actuator_gainprm.shape[0] == 2
 
-    print(next_batch_data.qpos)
+    # The randomized parameters should be different from the original model
+    assert not jnp.allclose(
+        ctrl2.model.actuator_gainprm[0], task.model.actuator_gainprm
+    )
 
 
 def test_opt() -> None:
@@ -120,5 +56,5 @@ def test_opt() -> None:
 
 
 if __name__ == "__main__":
-    # test_domain_randomization()
+    test_domain_randomization()
     test_opt()

--- a/tests/test_dr.py
+++ b/tests/test_dr.py
@@ -16,12 +16,16 @@ def test_domain_randomization() -> None:
     )
 
     # The models should have different numbers of randomizations
-    assert ctrl1.model.actuator_gainprm.shape[0] == 1
-    assert ctrl2.model.actuator_gainprm.shape[0] == 2
+    original_shape = task.model.actuator_gainprm.shape
+    assert ctrl1.model.actuator_gainprm.shape == original_shape
+    assert ctrl2.model.actuator_gainprm.shape == (2, *original_shape)
 
     # The randomized parameters should be different from the original model
     assert not jnp.allclose(
         ctrl2.model.actuator_gainprm[0], task.model.actuator_gainprm
+    )
+    assert jnp.allclose(
+        ctrl1.model.actuator_gainprm, task.model.actuator_gainprm
     )
 
 

--- a/tests/test_dr.py
+++ b/tests/test_dr.py
@@ -114,9 +114,9 @@ def test_opt() -> None:
     # Check the updated parameters
     assert params.mean.shape == (4, 2)
 
-    print(params)
-
-    print(params.mean.shape)
+    # Check that the rollout costs are different across different models
+    costs = jnp.sum(rollouts.costs, axis=(1, 2))
+    assert not jnp.allclose(costs[0], costs[1])
 
 
 if __name__ == "__main__":

--- a/tests/test_mppi.py
+++ b/tests/test_mppi.py
@@ -23,7 +23,9 @@ def test_open_loop() -> None:
         params, _ = jit_opt(state, params)
 
     # Roll out the solution, check that it's good enough
-    final_rollout = jax.jit(opt.eval_rollouts)(state, params.mean[None])
+    final_rollout = jax.jit(opt.eval_rollouts)(
+        task.model, state, params.mean[None]
+    )
     total_cost = jnp.sum(final_rollout.costs[0])
     assert total_cost <= 9.0
 


### PR DESCRIPTION
Adds tools for domain randomization.

Now a `Task` has optional `domain_randomize_model` and `domain_randomize_data` functions that specify the randomization. Rollouts are parallelized across both control tapes and randomized domains, with the same control tape applied in each domain.

It's then up to the planner to figure out what to do with the resulting rollout data (size `[domains, rollouts, timesteps]`). For the existing planners we just take an average cost over the domains.