### PR TITLE
Bump mujoco version to 3.2.4

### DIFF
--- a/hydrax/models/cube/scene.xml
+++ b/hydrax/models/cube/scene.xml
@@ -39,7 +39,7 @@
   <!-- Sensors for the cube -->
   <sensor>
     <framepos name="cube_position" objtype="body" objname="cube" reftype="site" refname="grasp_site" />
-    <framequat name="cube_orientation" objtype="body" objname="cube" />
+    <framequat name="cube_orientation" objtype="body" objname="cube" reftype="body" refname="goal"/>
   </sensor>
 
 </mujoco>

--- a/hydrax/tasks/cube.py
+++ b/hydrax/tasks/cube.py
@@ -44,10 +44,8 @@ class CubeRotation(Task):
         sensor_adr = self.model.sensor_adr[self.cube_orientation_sensor]
         cube_quat = state.sensordata[sensor_adr : sensor_adr + 4]
 
-        # N.B. we could define a sensor relative to the goal cube, but it looks
-        # like mocap states are not fully implemented yet in MJX, so we'll do
-        # this manually for now.
-        goal_quat = state.mocap_quat[0]
+        # Quaternion subtraction gives us rotation relative to goal
+        goal_quat = jnp.array([1.0, 0.0, 0.0, 0.0])
         return mjx._src.math.quat_sub(cube_quat, goal_quat)
 
     def running_cost(self, state: mjx.Data, control: jax.Array) -> jax.Array:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,8 +22,8 @@ dependencies = [
     "ruff>=0.4.10",
     "pre-commit>=3.7.1",
     "matplotlib>=3.8.3",
-    "mujoco>=3.2.3",
-    "mujoco-mjx>=3.2.3",
+    "mujoco>=3.2.4",
+    "mujoco-mjx>=3.2.4",
     "evosax>=0.1.6",
 ]
 

--- a/tests/test_dr.py
+++ b/tests/test_dr.py
@@ -39,7 +39,6 @@ def test_opt() -> None:
 
     # Create a random initial state
     state = mjx.make_data(task.model)
-    state = state.replace(mocap_pos=jnp.array([[0.5, 0.5, 0.0]]))
     assert state.qpos.shape == (2,)
 
     # Run an optimization step

--- a/tests/test_particle.py
+++ b/tests/test_particle.py
@@ -10,7 +10,6 @@ def test_particle() -> None:
     assert task.pointmass_id >= 0
 
     state = mjx.make_data(task.model)
-    state = state.replace(mocap_pos=jnp.zeros((1, 3)))
     assert isinstance(state, mjx.Data)
     assert state.site_xpos.shape == (1, 3)
     state = mjx.forward(task.model, state)  # compute site positions


### PR DESCRIPTION
This allows us to use `mocap_pos` and `mocap_quat` in MJX with less hackiness. For instance, we can define a sensor that gives the cube orientation relative to the goal cube directly.