### PR TITLE
Implement risk strategies

### DIFF
--- a/examples/particle.py
+++ b/examples/particle.py
@@ -7,6 +7,7 @@ import numpy as np
 from hydrax import ROOT
 from hydrax.algs import MPPI, Evosax, PredictiveSampling
 from hydrax.mpc import run_interactive
+from hydrax.risk import WorstCase
 from hydrax.tasks.particle import Particle
 
 """
@@ -22,7 +23,11 @@ task = Particle()
 if len(sys.argv) == 1 or sys.argv[1] == "ps":
     print("Running predictive sampling")
     ctrl = PredictiveSampling(
-        task, num_samples=16, noise_level=0.1, num_randomizations=10
+        task,
+        num_samples=16,
+        noise_level=0.1,
+        num_randomizations=10,
+        risk_strategy=WorstCase(),
     )
 
 elif sys.argv[1] == "mppi":

--- a/hydrax/alg_base.py
+++ b/hydrax/alg_base.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 from flax.struct import dataclass
 from mujoco import mjx
 
-from hydrax.risk import AverageCost
+from hydrax.risk import AverageCost, RiskStrategy
 from hydrax.task_base import Task
 
 
@@ -35,20 +35,28 @@ class Trajectory:
 class SamplingBasedController(ABC):
     """An abstract sampling-based MPC algorithm interface."""
 
-    def __init__(self, task: Task, num_randomizations: int, seed: int):
+    def __init__(
+        self,
+        task: Task,
+        num_randomizations: int,
+        risk_strategy: RiskStrategy,
+        seed: int,
+    ):
         """Initialize the MPC controller.
 
         Args:
             task: The task instance defining the dynamics and costs.
             num_randomizations: The number of domain randomizations to use.
+            risk_strategy: How to combining costs from different randomizations.
             seed: The random seed for domain randomization.
         """
         self.task = task
         self.num_randomizations = max(num_randomizations, 1)
 
-        # Risk strategy
-        # TODO: set as parameter
-        self.risk_strategy = AverageCost()
+        # Risk strategy defaults to average cost
+        if risk_strategy is None:
+            risk_strategy = AverageCost()
+        self.risk_strategy = risk_strategy
 
         # Use a single model (no domain randomization) by default
         self.model = task.model

--- a/hydrax/algs/cem.py
+++ b/hydrax/algs/cem.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 from flax.struct import dataclass
 
 from hydrax.alg_base import SamplingBasedController, Trajectory
+from hydrax.risk import RiskStrategy
 from hydrax.task_base import Task
 
 
@@ -34,6 +35,7 @@ class CEM(SamplingBasedController):
         sigma_start: float,
         sigma_min: float,
         num_randomizations: int = 1,
+        risk_strategy: RiskStrategy = None,
         seed: int = 0,
     ):
         """Initialize the controller.
@@ -45,9 +47,11 @@ class CEM(SamplingBasedController):
             sigma_start: The initial standard deviation for the controls.
             sigma_min: The minimum standard deviation for the controls.
             num_randomizations: The number of domain randomizations to use.
+            risk_strategy: How to combining costs from different randomizations.
+                           Defaults to average cost.
             seed: The random seed for domain randomization.
         """
-        super().__init__(task, num_randomizations, seed)
+        super().__init__(task, num_randomizations, risk_strategy, seed)
         self.num_samples = num_samples
         self.sigma_min = sigma_min
         self.sigma_start = sigma_start

--- a/hydrax/algs/cem.py
+++ b/hydrax/algs/cem.py
@@ -78,17 +78,17 @@ class CEM(SamplingBasedController):
         self, params: CEMParams, rollouts: Trajectory
     ) -> CEMParams:
         """Update the mean with an exponentially weighted average."""
-        controls = rollouts.controls[0]  # identical over randomizations
-        costs = jnp.mean(rollouts.costs, axis=0)  # avg. over randomizations
-        costs = jnp.sum(costs, axis=1)  # sum over time steps
+        costs = jnp.sum(rollouts.costs, axis=1)  # sum over time steps
 
         # Sort the costs and get the indices of the elites.
         indices = jnp.argsort(costs)
         elites = indices[: self.num_elites]
 
         # The new proposal distribution is a Gaussian fit to the elites.
-        mean = jnp.mean(controls[elites], axis=0)
-        cov = jnp.maximum(jnp.std(controls[elites], axis=0), self.sigma_min)
+        mean = jnp.mean(rollouts.controls[elites], axis=0)
+        cov = jnp.maximum(
+            jnp.std(rollouts.controls[elites], axis=0), self.sigma_min
+        )
 
         return params.replace(mean=mean, cov=cov)
 

--- a/hydrax/algs/evosax.py
+++ b/hydrax/algs/evosax.py
@@ -104,17 +104,14 @@ class Evosax(SamplingBasedController):
         self, params: EvosaxParams, rollouts: Trajectory
     ) -> EvosaxParams:
         """Update the policy parameters based on the rollouts."""
-        controls = rollouts.controls[0]  # identical over randomizations
-        costs = jnp.mean(rollouts.costs, axis=0)  # avg. over randomizations
-
-        costs = jnp.sum(costs, axis=1)  # sum over time steps
-        x = jnp.reshape(controls, (self.strategy.popsize, -1))
+        costs = jnp.sum(rollouts.costs, axis=1)  # sum over time steps
+        x = jnp.reshape(rollouts.controls, (self.strategy.popsize, -1))
         opt_state = self.strategy.tell(
             x, costs, params.opt_state, self.es_params
         )
 
         best_idx = jnp.argmin(costs)
-        best_controls = controls[best_idx]
+        best_controls = rollouts.controls[best_idx]
 
         # By default, opt_state stores the best member ever, rather than the
         # best member from the current generation. We want to just use the best

--- a/hydrax/algs/evosax.py
+++ b/hydrax/algs/evosax.py
@@ -6,6 +6,7 @@ import jax.numpy as jnp
 from flax.struct import dataclass
 
 from hydrax.alg_base import SamplingBasedController, Trajectory
+from hydrax.risk import RiskStrategy
 from hydrax.task_base import Task
 
 # Generic types for evosax
@@ -42,6 +43,7 @@ class Evosax(SamplingBasedController):
         num_samples: int,
         es_params: EvoParams = None,
         num_randomizations: int = 1,
+        risk_strategy: RiskStrategy = None,
         seed: int = 0,
         **kwargs,
     ):
@@ -53,10 +55,12 @@ class Evosax(SamplingBasedController):
             num_samples: The number of control tapes to sample.
             es_params: The parameters for the evosax optimizer.
             num_randomizations: The number of domain randomizations to use.
+            risk_strategy: How to combining costs from different randomizations.
+                           Defaults to average cost.
             seed: The random seed for domain randomization.
             **kwargs: Additional keyword arguments for the optimizer.
         """
-        super().__init__(task, num_randomizations, seed)
+        super().__init__(task, num_randomizations, risk_strategy, seed)
 
         self.strategy = optimizer(
             popsize=num_samples,

--- a/hydrax/algs/mppi.py
+++ b/hydrax/algs/mppi.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 from flax.struct import dataclass
 
 from hydrax.alg_base import SamplingBasedController, Trajectory
+from hydrax.risk import RiskStrategy
 from hydrax.task_base import Task
 
 
@@ -37,6 +38,7 @@ class MPPI(SamplingBasedController):
         noise_level: float,
         temperature: float,
         num_randomizations: int = 1,
+        risk_strategy: RiskStrategy = None,
         seed: int = 0,
     ):
         """Initialize the controller.
@@ -48,9 +50,11 @@ class MPPI(SamplingBasedController):
             temperature: The temperature parameter λ. Higher values take a more
                          even average over the samples.
             num_randomizations: The number of domain randomizations to use.
-            seed: The random seed for domain randomization
+            risk_strategy: How to combining costs from different randomizations.
+                           Defaults to average cost.
+            seed: The random seed for domain randomization.
         """
-        super().__init__(task, num_randomizations, seed)
+        super().__init__(task, num_randomizations, risk_strategy, seed)
         self.noise_level = noise_level
         self.num_samples = num_samples
         self.temperature = temperature

--- a/hydrax/algs/mppi.py
+++ b/hydrax/algs/mppi.py
@@ -81,12 +81,10 @@ class MPPI(SamplingBasedController):
         self, params: MPPIParams, rollouts: Trajectory
     ) -> MPPIParams:
         """Update the mean with an exponentially weighted average."""
-        costs = jnp.mean(rollouts.costs, axis=0)  # avg. over randomizations
-        controls = rollouts.controls[0]  # identical over randomizations
-        costs = jnp.sum(costs, axis=1)
+        costs = jnp.sum(rollouts.costs, axis=1)  # sum over time steps
         # N.B. jax.nn.softmax takes care of details like baseline subtraction.
         weights = jax.nn.softmax(-costs / self.temperature, axis=0)
-        mean = jnp.sum(weights[:, None, None] * controls, axis=0)
+        mean = jnp.sum(weights[:, None, None] * rollouts.controls, axis=0)
         return params.replace(mean=mean)
 
     def get_action(self, params: MPPIParams, t: float) -> jax.Array:

--- a/hydrax/algs/predictive_sampling.py
+++ b/hydrax/algs/predictive_sampling.py
@@ -71,11 +71,9 @@ class PredictiveSampling(SamplingBasedController):
 
     def update_params(self, params: PSParams, rollouts: Trajectory) -> PSParams:
         """Update the policy parameters by choosing the lowest-cost rollout."""
-        costs = jnp.mean(rollouts.costs, axis=0)  # avg. over randomizations
-        controls = rollouts.controls[0]  # identical over randomizations
-        costs = jnp.sum(costs, axis=1)  # sum over time steps
+        costs = jnp.sum(rollouts.costs, axis=1)  # sum over time steps
         best_idx = jnp.argmin(costs)
-        mean = controls[best_idx]
+        mean = rollouts.controls[best_idx]
         return params.replace(mean=mean)
 
     def get_action(self, params: PSParams, t: float) -> jax.Array:

--- a/hydrax/algs/predictive_sampling.py
+++ b/hydrax/algs/predictive_sampling.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 from flax.struct import dataclass
 
 from hydrax.alg_base import SamplingBasedController, Trajectory
+from hydrax.risk import RiskStrategy
 from hydrax.task_base import Task
 
 
@@ -30,6 +31,7 @@ class PredictiveSampling(SamplingBasedController):
         num_samples: int,
         noise_level: float,
         num_randomizations: int = 1,
+        risk_strategy: RiskStrategy = None,
         seed: int = 0,
     ):
         """Initialize the controller.
@@ -39,9 +41,11 @@ class PredictiveSampling(SamplingBasedController):
             num_samples: The number of control tapes to sample.
             noise_level: The scale of Gaussian noise to add to sampled controls.
             num_randomizations: The number of domain randomizations to use.
-            seed: The random seed for domain randomization
+            risk_strategy: How to combining costs from different randomizations.
+                           Defaults to average cost.
+            seed: The random seed for domain randomization.
         """
-        super().__init__(task, num_randomizations, seed)
+        super().__init__(task, num_randomizations, risk_strategy, seed)
         self.noise_level = noise_level
         self.num_samples = num_samples
 

--- a/hydrax/risk.py
+++ b/hydrax/risk.py
@@ -1,0 +1,38 @@
+from abc import ABC, abstractmethod
+
+import jax
+import jax.numpy as jnp
+
+
+class RiskStrategy(ABC):
+    """An abstract risk strategy interface.
+
+    A risk strategy defines how we combine costs from different domains with
+    domain randomization. For example, a very risk-averse strategy might take
+    the worst-case cost over all randomizations, while a risk-seeking strategy
+    might take the best-case cost.
+    """
+
+    @abstractmethod
+    def combine_costs(self, costs: jax.Array) -> jax.Array:
+        """Combine costs from different randomizations.
+
+        Args:
+            costs: rollout costs, first axis is the randomization index.
+
+        Returns:
+            The combined cost (scalar).
+        """
+        pass
+
+
+class AverageCost(RiskStrategy):
+    """Average cost risk strategy.
+
+    This is the standard expectation over randomizations that is often used in
+    reinforcement learning.
+    """
+
+    def combine_costs(self, costs: jax.Array) -> jax.Array:
+        """Take the average cost over all randomizations."""
+        return jnp.mean(costs, axis=0)

--- a/hydrax/risk.py
+++ b/hydrax/risk.py
@@ -36,3 +36,19 @@ class AverageCost(RiskStrategy):
     def combine_costs(self, costs: jax.Array) -> jax.Array:
         """Take the average cost over all randomizations."""
         return jnp.mean(costs, axis=0)
+
+
+class WorstCase(RiskStrategy):
+    """A pessimistic worst-case-cost risk strategy."""
+
+    def combine_costs(self, costs: jax.Array) -> jax.Array:
+        """Take the highest cost over all randomizations."""
+        return jnp.max(costs, axis=0)
+
+
+class BestCase(RiskStrategy):
+    """An optimistic best-case-cost risk strategy."""
+
+    def combine_costs(self, costs: jax.Array) -> jax.Array:
+        """Take the lowest cost over all randomizations."""
+        return jnp.min(costs, axis=0)

--- a/hydrax/risk.py
+++ b/hydrax/risk.py
@@ -52,3 +52,24 @@ class BestCase(RiskStrategy):
     def combine_costs(self, costs: jax.Array) -> jax.Array:
         """Take the lowest cost over all randomizations."""
         return jnp.min(costs, axis=0)
+
+
+class ExponentialWeightedAverage(RiskStrategy):
+    """An exponential weighted average risk strategy.
+
+    Costs are combined using a weighted average with weights
+
+        wᵢ = exp(γ cᵢ)/∑ⱼexp(γ cⱼ).
+
+    The parameter γ controls the risk-aversion of the strategy: positive values
+    encode a risk-averse strategy, while negative values lead to risk-seeking.
+    """
+
+    def __init__(self, gamma: float):
+        """Set the risk-aversion parameter γ."""
+        self.gamma = gamma
+
+    def combine_costs(self, costs: jax.Array) -> jax.Array:
+        """Combine costs using an exponential weighted average."""
+        weights = jax.nn.softmax(self.gamma * costs, axis=0)
+        return jnp.sum(weights * costs, axis=0)

--- a/hydrax/risk.py
+++ b/hydrax/risk.py
@@ -85,3 +85,16 @@ class ValueAtRisk(RiskStrategy):
     def combine_costs(self, costs: jax.Array) -> jax.Array:
         """Take the cost value at the (1 - α) quantile."""
         return jnp.quantile(costs, 1.0 - self.alpha, axis=0)
+
+
+class ConditionalValueAtRisk(RiskStrategy):
+    """Take the expected cost in the tail beyond the (1 - α) quantile."""
+
+    def __init__(self, alpha: float):
+        """Set the quantile level α."""
+        self.alpha = alpha
+
+    def combine_costs(self, costs: jax.Array) -> jax.Array:
+        """Take the expected cost in the tail beyond the (1 - α) quantile."""
+        quant = jnp.quantile(costs, 1.0 - self.alpha, axis=0)
+        return jnp.mean(costs, where=costs >= quant, axis=0)

--- a/hydrax/risk.py
+++ b/hydrax/risk.py
@@ -73,3 +73,15 @@ class ExponentialWeightedAverage(RiskStrategy):
         """Combine costs using an exponential weighted average."""
         weights = jax.nn.softmax(self.gamma * costs, axis=0)
         return jnp.sum(weights * costs, axis=0)
+
+
+class ValueAtRisk(RiskStrategy):
+    """Take the cost value at the (1 - α) quantile."""
+
+    def __init__(self, alpha: float):
+        """Set the quantile level α."""
+        self.alpha = alpha
+
+    def combine_costs(self, costs: jax.Array) -> jax.Array:
+        """Take the cost value at the (1 - α) quantile."""
+        return jnp.quantile(costs, 1.0 - self.alpha, axis=0)

--- a/hydrax/risk.py
+++ b/hydrax/risk.py
@@ -18,10 +18,10 @@ class RiskStrategy(ABC):
         """Combine costs from different randomizations.
 
         Args:
-            costs: rollout costs, first axis is the randomization index.
+            costs: rollout costs, size (randomizations, samples, horizon)
 
         Returns:
-            The combined cost (scalar).
+            The combined cost, size (samples, horizon).
         """
         pass
 

--- a/tests/test_cma_es.py
+++ b/tests/test_cma_es.py
@@ -27,16 +27,8 @@ def test_cmaes() -> None:
     rollouts = ctrl.eval_rollouts(task.model, state, controls)
     assert rollouts.costs.shape == (32, 20)
 
-    # Roll out the control sequences with domain randomization
-    batch_state = jax.vmap(lambda _, x: x, in_axes=(0, None))(
-        jnp.arange(ctrl.num_randomizations), state
-    )
-    batch_rollouts = jax.vmap(
-        ctrl.eval_rollouts, in_axes=(ctrl.randomized_axes, 0, None)
-    )(ctrl.model, batch_state, controls)
-
     # Update the policy parameters
-    params = ctrl.update_params(params, batch_rollouts)
+    params = ctrl.update_params(params, rollouts)
     assert params.controls.shape == (19, 1)
     assert jnp.all(params.controls != jnp.zeros((19, 1)))
     assert params.opt_state.best_fitness > 0.0

--- a/tests/test_predictive_sampling.py
+++ b/tests/test_predictive_sampling.py
@@ -48,8 +48,7 @@ def test_predictive_sampling() -> None:
     )
 
     # Pick the best rollout
-    batch_rollouts = jax.tree.map(lambda x: x[None], rollouts)
-    updated_params = opt.update_params(new_params, batch_rollouts)
+    updated_params = opt.update_params(new_params, rollouts)
     assert updated_params.mean.shape == (task.planning_horizon - 1, 1)
     assert jnp.all(updated_params.mean != new_params.mean)
 

--- a/tests/test_risk_strategies.py
+++ b/tests/test_risk_strategies.py
@@ -1,0 +1,28 @@
+import jax
+import jax.numpy as jnp
+
+from hydrax.risk import AverageCost, BestCase, WorstCase
+
+
+def test_risk() -> None:
+    """Quick sanity check on various risk strategies."""
+    rng = jax.random.key(0)
+
+    n, m = 10, 20
+    costs = jax.random.normal(rng, (n, m))
+
+    avg = AverageCost().combine_costs(costs)
+    assert avg.shape == (m,)
+
+    worst = WorstCase().combine_costs(costs)
+    assert worst.shape == (m,)
+
+    best = BestCase().combine_costs(costs)
+    assert best.shape == (m,)
+
+    assert jnp.all(avg <= worst)
+    assert jnp.all(avg >= best)
+
+
+if __name__ == "__main__":
+    test_risk()

--- a/tests/test_risk_strategies.py
+++ b/tests/test_risk_strategies.py
@@ -5,6 +5,7 @@ from hydrax.risk import (
     AverageCost,
     BestCase,
     ExponentialWeightedAverage,
+    ValueAtRisk,
     WorstCase,
 )
 
@@ -28,11 +29,16 @@ def test_risk() -> None:
     weighted = ExponentialWeightedAverage(2.0).combine_costs(costs)
     assert weighted.shape == (m,)
 
+    var = ValueAtRisk(0.1).combine_costs(costs)
+    assert var.shape == (m,)
+
     assert jnp.all(avg <= worst)
     assert jnp.all(avg >= best)
     assert jnp.all(weighted <= worst)
     assert jnp.all(weighted >= best)
     assert jnp.all(weighted >= avg)
+    assert jnp.all(var <= worst)
+    assert jnp.all(var >= avg)
 
 
 if __name__ == "__main__":

--- a/tests/test_risk_strategies.py
+++ b/tests/test_risk_strategies.py
@@ -1,7 +1,12 @@
 import jax
 import jax.numpy as jnp
 
-from hydrax.risk import AverageCost, BestCase, WorstCase
+from hydrax.risk import (
+    AverageCost,
+    BestCase,
+    ExponentialWeightedAverage,
+    WorstCase,
+)
 
 
 def test_risk() -> None:
@@ -20,8 +25,14 @@ def test_risk() -> None:
     best = BestCase().combine_costs(costs)
     assert best.shape == (m,)
 
+    weighted = ExponentialWeightedAverage(2.0).combine_costs(costs)
+    assert weighted.shape == (m,)
+
     assert jnp.all(avg <= worst)
     assert jnp.all(avg >= best)
+    assert jnp.all(weighted <= worst)
+    assert jnp.all(weighted >= best)
+    assert jnp.all(weighted >= avg)
 
 
 if __name__ == "__main__":

--- a/tests/test_risk_strategies.py
+++ b/tests/test_risk_strategies.py
@@ -4,6 +4,7 @@ import jax.numpy as jnp
 from hydrax.risk import (
     AverageCost,
     BestCase,
+    ConditionalValueAtRisk,
     ExponentialWeightedAverage,
     ValueAtRisk,
     WorstCase,
@@ -14,7 +15,7 @@ def test_risk() -> None:
     """Quick sanity check on various risk strategies."""
     rng = jax.random.key(0)
 
-    n, m = 10, 20
+    n, m = 10, 2
     costs = jax.random.normal(rng, (n, m))
 
     avg = AverageCost().combine_costs(costs)
@@ -32,6 +33,12 @@ def test_risk() -> None:
     var = ValueAtRisk(0.1).combine_costs(costs)
     assert var.shape == (m,)
 
+    cvar = ConditionalValueAtRisk(0.1).combine_costs(costs)
+    assert cvar.shape == (m,)
+
+    assert jnp.all(ConditionalValueAtRisk(0.0).combine_costs(costs) == worst)
+    assert jnp.all(ConditionalValueAtRisk(1.0).combine_costs(costs) == avg)
+
     assert jnp.all(avg <= worst)
     assert jnp.all(avg >= best)
     assert jnp.all(weighted <= worst)
@@ -39,6 +46,8 @@ def test_risk() -> None:
     assert jnp.all(weighted >= avg)
     assert jnp.all(var <= worst)
     assert jnp.all(var >= avg)
+    assert jnp.all(cvar >= var)
+    assert jnp.all(cvar <= worst)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a generic interface specifying how to combine costs over randomized domains.

- Risk strategy is independent of planner: can be re-used across different planners
- The default is to take the simple average (what we were using before)
- Includes implementations of several risk strategies (worst-case, best-case, exponential, VaR, CVaR)