### PR TITLE
Update planning horizon semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Hydrax considers optimal control problems of the form
 
 ```math
 \begin{align}
-\min_{u_t} & \sum_{t=0}^{T-1} \ell(x_t, u_t) + \phi(x_T), \\
+\min_{u_t} & \sum_{t=0}^{T} \ell(x_t, u_t) + \phi(x_{T+1}), \\
 \mathrm{s.t.}~& x_{t+1} = f(x_t, u_t),
 \end{align}
 ```

--- a/hydrax/alg_base.py
+++ b/hydrax/alg_base.py
@@ -28,7 +28,7 @@ class Trajectory:
     trace_sites: jax.Array
 
     def __len__(self):
-        """Return the number of time steps in the trajectory (N)."""
+        """Return the number of time steps in the trajectory (T)."""
         return self.costs.shape[-1] - 1
 
 

--- a/hydrax/alg_base.py
+++ b/hydrax/alg_base.py
@@ -16,10 +16,10 @@ class Trajectory:
     """Data class for storing rollout data.
 
     Attributes:
-        controls: Control actions for each time step (size N - 1).
-        costs: Costs associated with each time step (size N).
-        observations: Observations at each time step (size N).
-        trace_sites: Positions of trace sites at each time step (size N).
+        controls: Control actions for each time step (size T).
+        costs: Costs associated with each time step (size T+1).
+        observations: Observations at each time step (size T+1).
+        trace_sites: Positions of trace sites at each time step (size T+1).
     """
 
     controls: jax.Array
@@ -29,7 +29,7 @@ class Trajectory:
 
     def __len__(self):
         """Return the number of time steps in the trajectory (N)."""
-        return self.costs.shape[-1]
+        return self.costs.shape[-1] - 1
 
 
 class SamplingBasedController(ABC):

--- a/hydrax/algs/cem.py
+++ b/hydrax/algs/cem.py
@@ -60,7 +60,7 @@ class CEM(SamplingBasedController):
     def init_params(self, seed: int = 0) -> CEMParams:
         """Initialize the policy parameters."""
         rng = jax.random.key(seed)
-        mean = jnp.zeros((self.task.planning_horizon - 1, self.task.model.nu))
+        mean = jnp.zeros((self.task.planning_horizon, self.task.model.nu))
         cov = jnp.full_like(mean, self.sigma_start)
         return CEMParams(mean=mean, cov=cov, rng=rng)
 
@@ -71,7 +71,7 @@ class CEM(SamplingBasedController):
             sample_rng,
             (
                 self.num_samples,
-                self.task.planning_horizon - 1,
+                self.task.planning_horizon,
                 self.task.model.nu,
             ),
         )

--- a/hydrax/algs/evosax.py
+++ b/hydrax/algs/evosax.py
@@ -64,7 +64,7 @@ class Evosax(SamplingBasedController):
 
         self.strategy = optimizer(
             popsize=num_samples,
-            num_dims=task.model.nu * (task.planning_horizon - 1),
+            num_dims=task.model.nu * task.planning_horizon,
             **kwargs,
         )
 
@@ -76,9 +76,7 @@ class Evosax(SamplingBasedController):
         """Initialize the policy parameters."""
         rng = jax.random.key(seed)
         rng, init_rng = jax.random.split(rng)
-        controls = jnp.zeros(
-            (self.task.planning_horizon - 1, self.task.model.nu)
-        )
+        controls = jnp.zeros((self.task.planning_horizon, self.task.model.nu))
         opt_state = self.strategy.initialize(init_rng, self.es_params)
         return EvosaxParams(controls=controls, opt_state=opt_state, rng=rng)
 
@@ -92,12 +90,12 @@ class Evosax(SamplingBasedController):
         )
 
         # evosax works with vectors of decision variables, so we reshape U to
-        # [batch_size, horizon - 1, nu].
+        # [batch_size, horizon, nu].
         controls = jnp.reshape(
             x,
             (
                 self.strategy.popsize,
-                self.task.planning_horizon - 1,
+                self.task.planning_horizon,
                 self.task.model.nu,
             ),
         )

--- a/hydrax/algs/mppi.py
+++ b/hydrax/algs/mppi.py
@@ -62,7 +62,7 @@ class MPPI(SamplingBasedController):
     def init_params(self, seed: int = 0) -> MPPIParams:
         """Initialize the policy parameters."""
         rng = jax.random.key(seed)
-        mean = jnp.zeros((self.task.planning_horizon - 1, self.task.model.nu))
+        mean = jnp.zeros((self.task.planning_horizon, self.task.model.nu))
         return MPPIParams(mean=mean, rng=rng)
 
     def sample_controls(
@@ -74,7 +74,7 @@ class MPPI(SamplingBasedController):
             sample_rng,
             (
                 self.num_samples,
-                self.task.planning_horizon - 1,
+                self.task.planning_horizon,
                 self.task.model.nu,
             ),
         )

--- a/hydrax/algs/predictive_sampling.py
+++ b/hydrax/algs/predictive_sampling.py
@@ -52,7 +52,7 @@ class PredictiveSampling(SamplingBasedController):
     def init_params(self, seed: int = 0) -> PSParams:
         """Initialize the policy parameters."""
         rng = jax.random.key(seed)
-        mean = jnp.zeros((self.task.planning_horizon - 1, self.task.model.nu))
+        mean = jnp.zeros((self.task.planning_horizon, self.task.model.nu))
         return PSParams(mean=mean, rng=rng)
 
     def sample_controls(self, params: PSParams) -> Tuple[jax.Array, PSParams]:
@@ -62,7 +62,7 @@ class PredictiveSampling(SamplingBasedController):
             sample_rng,
             (
                 self.num_samples,
-                self.task.planning_horizon - 1,
+                self.task.planning_horizon,
                 self.task.model.nu,
             ),
         )

--- a/hydrax/mpc.py
+++ b/hydrax/mpc.py
@@ -48,10 +48,9 @@ def run_interactive(
     mj_data.qvel[:] = start_state[mj_model.nq :]
 
     # Report the planning horizon in seconds for debugging
-    num_steps = controller.task.planning_horizon - 1
     print(
-        f"Planning with {num_steps} steps "
-        f"over a {num_steps * controller.task.dt} "
+        f"Planning with {controller.task.planning_horizon} steps "
+        f"over a {controller.task.planning_horizon * controller.task.dt} "
         f"second horizon."
     )
 

--- a/hydrax/task_base.py
+++ b/hydrax/task_base.py
@@ -12,11 +12,11 @@ class Task(ABC):
 
     The task is a discrete-time optimal control problem of the form
 
-        minᵤ ϕ(x_T) + ∑ₜ ℓ(xₜ, uₜ)
+        minᵤ ϕ(x_{T+1}) + ∑ₜ ℓ(xₜ, uₜ)
         s.t. xₜ₊₁ = f(xₜ, uₜ)
 
     where the dynamics f(xₜ, uₜ) are defined by a MuJoCo model, and the costs
-    ℓ(xₜ, uₜ) and ϕ(x_T) are defined by the task instance itself.
+    ℓ(xₜ, uₜ) and ϕ(x_{T+1}) are defined by the task instance itself.
     """
 
     def __init__(
@@ -30,7 +30,7 @@ class Task(ABC):
 
         Args:
             mj_model: The MuJoCo model to use for simulation.
-            planning_horizon: The number of control steps to plan over.
+            planning_horizon: The number of control steps (T) to plan over.
             sim_steps_per_control_step: The number of simulation steps to take
                                         for each control step.
             trace_sites: A list of site names to visualize with traces.

--- a/hydrax/tasks/cube.py
+++ b/hydrax/tasks/cube.py
@@ -18,7 +18,7 @@ class CubeRotation(Task):
 
         super().__init__(
             mj_model,
-            planning_horizon=4,
+            planning_horizon=3,
             sim_steps_per_control_step=4,
             trace_sites=["cube_center", "if_tip", "mf_tip", "rf_tip", "th_tip"],
         )

--- a/hydrax/tasks/humanoid.py
+++ b/hydrax/tasks/humanoid.py
@@ -16,7 +16,7 @@ class Humanoid(Task):
 
         super().__init__(
             mj_model,
-            planning_horizon=3,
+            planning_horizon=2,
             sim_steps_per_control_step=50,
             trace_sites=["imu", "left_foot", "right_foot"],
         )

--- a/hydrax/tasks/walker.py
+++ b/hydrax/tasks/walker.py
@@ -18,7 +18,7 @@ class Walker(Task):
 
         super().__init__(
             mj_model,
-            planning_horizon=5,
+            planning_horizon=4,
             sim_steps_per_control_step=15,
             trace_sites=["torso_site"],
         )

--- a/tests/test_alg_base.py
+++ b/tests/test_alg_base.py
@@ -6,10 +6,10 @@ from hydrax.alg_base import Trajectory
 def test_traj() -> None:
     """Make sure we can define a Trajectory object."""
     batch, horizon = 5, 10
-    U = jnp.zeros((batch, horizon - 1, 3))
-    Y = jnp.zeros((batch, horizon, 4))
-    J = jnp.zeros((batch, horizon))
-    P = jnp.zeros((batch, horizon, 0, 3))
+    U = jnp.zeros((batch, horizon, 3))
+    Y = jnp.zeros((batch, horizon + 1, 4))
+    J = jnp.zeros((batch, horizon + 1))
+    P = jnp.zeros((batch, horizon + 1, 0, 3))
 
     traj = Trajectory(controls=U, costs=J, observations=Y, trace_sites=P)
     assert len(traj) == horizon

--- a/tests/test_cem.py
+++ b/tests/test_cem.py
@@ -35,7 +35,7 @@ def test_open_loop() -> None:
     if __name__ == "__main__":
         # Plot the solution
         _, ax = plt.subplots(3, 1, sharex=True)
-        times = jnp.arange(task.planning_horizon) * task.dt
+        times = jnp.arange(task.planning_horizon + 1) * task.dt
 
         ax[0].plot(times, final_rollout.observations[0, :, 0])
         ax[0].set_ylabel(r"$\theta$")

--- a/tests/test_cma_es.py
+++ b/tests/test_cma_es.py
@@ -15,22 +15,22 @@ def test_cmaes() -> None:
 
     # Initialize the policy parameters
     params = ctrl.init_params()
-    assert params.opt_state.C.shape == (19, 19)
+    assert params.opt_state.C.shape == (20, 20)
     assert params.opt_state.weights.shape == (32,)
 
     # Sample control sequences from the policy
     controls, params = ctrl.sample_controls(params)
-    assert controls.shape == (32, 19, 1)
+    assert controls.shape == (32, 20, 1)
 
     # Roll out the control sequences
     state = mjx.make_data(task.model)
     rollouts = ctrl.eval_rollouts(task.model, state, controls)
-    assert rollouts.costs.shape == (32, 20)
+    assert rollouts.costs.shape == (32, 21)
 
     # Update the policy parameters
     params = ctrl.update_params(params, rollouts)
-    assert params.controls.shape == (19, 1)
-    assert jnp.all(params.controls != jnp.zeros((19, 1)))
+    assert params.controls.shape == (20, 1)
+    assert jnp.all(params.controls != jnp.zeros((20, 1)))
     assert params.opt_state.best_fitness > 0.0
 
 
@@ -60,7 +60,7 @@ def test_open_loop() -> None:
     if __name__ == "__main__":
         # Plot the solution
         _, ax = plt.subplots(3, 1, sharex=True)
-        times = jnp.arange(task.planning_horizon) * task.dt
+        times = jnp.arange(task.planning_horizon + 1) * task.dt
 
         ax[0].plot(times, final_rollout.observations[0, :, 0])
         ax[0].set_ylabel(r"$\theta$")

--- a/tests/test_dr.py
+++ b/tests/test_dr.py
@@ -46,12 +46,12 @@ def test_opt() -> None:
 
     # Check the rollout shapes. Should be
     # (randomizations, samples, timestep, ...)
-    assert rollouts.costs.shape == (3, 11, 5)
-    assert rollouts.controls.shape == (3, 11, 4, 2)
-    assert rollouts.observations.shape == (3, 11, 5, 4)
+    assert rollouts.costs.shape == (3, 11, 6)
+    assert rollouts.controls.shape == (3, 11, 5, 2)
+    assert rollouts.observations.shape == (3, 11, 6, 4)
 
     # Check the updated parameters
-    assert params.mean.shape == (4, 2)
+    assert params.mean.shape == (5, 2)
 
     # Check that the rollout costs are different across different models
     costs = jnp.sum(rollouts.costs, axis=(1, 2))

--- a/tests/test_mppi.py
+++ b/tests/test_mppi.py
@@ -32,7 +32,7 @@ def test_open_loop() -> None:
     if __name__ == "__main__":
         # Plot the solution
         _, ax = plt.subplots(3, 1, sharex=True)
-        times = jnp.arange(task.planning_horizon) * task.dt
+        times = jnp.arange(task.planning_horizon + 1) * task.dt
 
         ax[0].plot(times, final_rollout.observations[0, :, 0])
         ax[0].set_ylabel(r"$\theta$")

--- a/tests/test_predictive_sampling.py
+++ b/tests/test_predictive_sampling.py
@@ -14,12 +14,12 @@ def test_predictive_sampling() -> None:
 
     # Initialize the policy parameters
     params = opt.init_params()
-    assert params.mean.shape == (task.planning_horizon - 1, 1)
+    assert params.mean.shape == (task.planning_horizon, 1)
     assert isinstance(params.rng, jax._src.prng.PRNGKeyArray)
 
     # Sample control sequences from the policy
     controls, new_params = opt.sample_controls(params)
-    assert controls.shape == (opt.num_samples + 1, task.planning_horizon - 1, 1)
+    assert controls.shape == (opt.num_samples + 1, task.planning_horizon, 1)
     assert new_params.rng != params.rng
 
     # Roll out the control sequences
@@ -28,28 +28,28 @@ def test_predictive_sampling() -> None:
 
     assert rollouts.costs.shape == (
         opt.num_samples + 1,
-        task.planning_horizon,
+        task.planning_horizon + 1,
     )
     assert rollouts.observations.shape == (
         opt.num_samples + 1,
-        task.planning_horizon,
+        task.planning_horizon + 1,
         2,
     )
     assert rollouts.controls.shape == (
         opt.num_samples + 1,
-        task.planning_horizon - 1,
+        task.planning_horizon,
         1,
     )
     assert rollouts.trace_sites.shape == (
         opt.num_samples + 1,
-        task.planning_horizon,
+        task.planning_horizon + 1,
         len(task.trace_site_ids),
         3,
     )
 
     # Pick the best rollout
     updated_params = opt.update_params(new_params, rollouts)
-    assert updated_params.mean.shape == (task.planning_horizon - 1, 1)
+    assert updated_params.mean.shape == (task.planning_horizon, 1)
     assert jnp.all(updated_params.mean != new_params.mean)
 
 
@@ -78,7 +78,7 @@ def test_open_loop() -> None:
     if __name__ == "__main__":
         # Plot the solution
         _, ax = plt.subplots(3, 1, sharex=True)
-        times = jnp.arange(task.planning_horizon) * task.dt
+        times = jnp.arange(task.planning_horizon + 1) * task.dt
 
         ax[0].plot(times, best_obs[:, 0])
         ax[0].set_ylabel(r"$\theta$")


### PR DESCRIPTION
Updates the meaning of `task.planning_horizon` to be more intuitively reasonable. Now `task.planning_horizon = N` indicates `N` control actions and `N+1` states. 

This is slightly different from the convention in discrete-time control, but means that the length of a rollout is `task.planning_horizon * task.dt` seconds, which makes way more sense to me. Also `N = 1` makes more sense this way.