### PR TITLE
Asynchronous simulation

### DIFF
--- a/examples/cube.py
+++ b/examples/cube.py
@@ -2,11 +2,10 @@ import sys
 
 import evosax
 import mujoco
-import numpy as np
 
 from hydrax import ROOT
 from hydrax.algs import CEM, MPPI, Evosax, PredictiveSampling
-from hydrax.mpc import run_interactive
+from hydrax.simulation.deterministic import run_interactive
 from hydrax.tasks.cube import CubeRotation
 
 """
@@ -59,13 +58,13 @@ else:
 
 # Define the model used for simulation
 mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/cube/scene.xml")
-start_state = np.concatenate([mj_model.qpos0, np.zeros(mj_model.nv)])
+mj_data = mujoco.MjData(mj_model)
 
 # Run the interactive simulation
 run_interactive(
-    mj_model,
     ctrl,
-    start_state,
+    mj_model,
+    mj_data,
     frequency=25,
     fixed_camera_id=None,
     show_traces=True,

--- a/examples/cube_async.py
+++ b/examples/cube_async.py
@@ -14,7 +14,9 @@ offers limited features (e.g., no trace visualization).
 
 
 # For asynchronous simulation, we need to define the task and controller inside
-# a function. This ensures that all jax code is isolated in one process.
+# a function. This ensures that all jax code is isolated in one process. Any
+# jax code outside that process will result in various inscrutable `os.fork()`
+# and `CUDA_ERROR_NOT_INITIALIZED` errors.
 def make_controller() -> PredictiveSampling:
     """Set up the controller."""
     task = CubeRotation()

--- a/examples/cube_async.py
+++ b/examples/cube_async.py
@@ -12,18 +12,18 @@ Asynchronous simulation is more realistic than deterministic simulation, but
 offers limited features (e.g., no trace visualization).
 """
 
+# Asynchronous simulations must be wrapped in a __main__ block, see
+# https://docs.python.org/3/library/multiprocessing.html
 if __name__ == "__main__":
-    # Asynchronous simulations must be wrapped in a __main__ block, see
-    # https://docs.python.org/3/library/multiprocessing.html
-
     # Define the task and controller
     task = CubeRotation()
-
-    ctrl = PredictiveSampling(task, num_samples=32, noise_level=0.2, num_randomizations=32)
+    ctrl = PredictiveSampling(
+        task, num_samples=32, noise_level=0.2, num_randomizations=32
+    )
 
     # Define the model used for simulation (with more realistic parameters)
     mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/cube/scene.xml")
-    mj_model.opt.timestep = 0.002
+    mj_model.opt.timestep = 0.005
     mj_model.opt.iterations = 100
     mj_model.opt.ls_iterations = 50
     mj_model.opt.cone = mujoco.mjtCone.mjCONE_ELLIPTIC

--- a/examples/cube_async.py
+++ b/examples/cube_async.py
@@ -12,30 +12,26 @@ Asynchronous simulation is more realistic than deterministic simulation, but
 offers limited features (e.g., no trace visualization).
 """
 
+if __name__ == "__main__":
+    # Asynchronous simulations must be wrapped in a __main__ block, see
+    # https://docs.python.org/3/library/multiprocessing.html
 
-# For asynchronous simulation, we need to define the task and controller inside
-# a function. This ensures that all jax code is isolated in one process. Any
-# jax code outside that process will result in various inscrutable `os.fork()`
-# and `CUDA_ERROR_NOT_INITIALIZED` errors.
-def make_controller() -> PredictiveSampling:
-    """Set up the controller."""
+    # Define the task and controller
     task = CubeRotation()
-    return PredictiveSampling(
-        task, num_samples=32, noise_level=0.2, num_randomizations=32
+
+    ctrl = PredictiveSampling(task, num_samples=32, noise_level=0.2, num_randomizations=32)
+
+    # Define the model used for simulation (with more realistic parameters)
+    mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/cube/scene.xml")
+    mj_model.opt.timestep = 0.002
+    mj_model.opt.iterations = 100
+    mj_model.opt.ls_iterations = 50
+    mj_model.opt.cone = mujoco.mjtCone.mjCONE_ELLIPTIC
+    mj_data = mujoco.MjData(mj_model)
+
+    # Run the interactive simulation
+    run_interactive(
+        ctrl,
+        mj_model,
+        mj_data,
     )
-
-
-# Define the model used for simulation (with more realistic parameters)
-mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/cube/scene.xml")
-mj_model.opt.timestep = 0.002
-mj_model.opt.iterations = 100
-mj_model.opt.ls_iterations = 50
-mj_model.opt.cone = mujoco.mjtCone.mjCONE_ELLIPTIC
-mj_data = mujoco.MjData(mj_model)
-
-# Run the interactive simulation
-run_interactive(
-    make_controller,
-    mj_model,
-    mj_data,
-)

--- a/examples/cube_async.py
+++ b/examples/cube_async.py
@@ -1,0 +1,39 @@
+import mujoco
+
+from hydrax import ROOT
+from hydrax.algs import PredictiveSampling
+from hydrax.simulation.asynchronous import run_interactive
+from hydrax.tasks.cube import CubeRotation
+
+"""
+Run an asynchronous interactive simulation of the cube rotation task.
+
+Asynchronous simulation is more realistic than deterministic simulation, but
+offers limited features (e.g., no trace visualization).
+"""
+
+
+# For asynchronous simulation, we need to define the task and controller inside
+# a function. This ensures that all jax code is isolated in one process.
+def make_controller() -> PredictiveSampling:
+    """Set up the controller."""
+    task = CubeRotation()
+    return PredictiveSampling(
+        task, num_samples=32, noise_level=0.2, num_randomizations=32
+    )
+
+
+# Define the model used for simulation (with more realistic parameters)
+mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/cube/scene.xml")
+mj_model.opt.timestep = 0.002
+mj_model.opt.iterations = 100
+mj_model.opt.ls_iterations = 50
+mj_model.opt.cone = mujoco.mjtCone.mjCONE_ELLIPTIC
+mj_data = mujoco.MjData(mj_model)
+
+# Run the interactive simulation
+run_interactive(
+    make_controller,
+    mj_model,
+    mj_data,
+)

--- a/examples/humanoid.py
+++ b/examples/humanoid.py
@@ -1,9 +1,8 @@
 import mujoco
-import numpy as np
 
 from hydrax import ROOT
 from hydrax.algs import PredictiveSampling
-from hydrax.mpc import run_interactive
+from hydrax.simulation.deterministic import run_interactive
 from hydrax.tasks.humanoid import Humanoid
 
 """
@@ -18,15 +17,16 @@ ctrl = PredictiveSampling(task, num_samples=128, noise_level=0.2)
 
 # Define the model used for simulation
 mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/g1/scene.xml")
-start_state = np.concatenate(
-    [mj_model.keyframe("stand").qpos, np.zeros(mj_model.nv)]
-)
+
+# Set the initial state
+mj_data = mujoco.MjData(mj_model)
+mj_data.qpos[:] = mj_model.keyframe("stand").qpos
 
 # Run the interactive simulation
 run_interactive(
-    mj_model,
     ctrl,
-    start_state,
+    mj_model,
+    mj_data,
     frequency=30,
     show_traces=True,
     max_traces=1,

--- a/examples/particle.py
+++ b/examples/particle.py
@@ -2,12 +2,11 @@ import sys
 
 import evosax
 import mujoco
-import numpy as np
 
 from hydrax import ROOT
 from hydrax.algs import MPPI, Evosax, PredictiveSampling
-from hydrax.mpc import run_interactive
 from hydrax.risk import WorstCase
+from hydrax.simulation.deterministic import run_interactive
 from hydrax.tasks.particle import Particle
 
 """
@@ -66,13 +65,13 @@ else:
 
 # Define the model used for simulation
 mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/particle/scene.xml")
-start_state = np.array([0.0, 0.0, 0.0, 0.0])
+mj_data = mujoco.MjData(mj_model)
 
 # Run the interactive simulation
 run_interactive(
-    mj_model,
     ctrl,
-    start_state,
+    mj_model,
+    mj_data,
     frequency=50,
     show_traces=True,
     max_traces=5,

--- a/examples/pendulum.py
+++ b/examples/pendulum.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from hydrax import ROOT
 from hydrax.algs import MPPI, PredictiveSampling
-from hydrax.mpc import run_interactive
+from hydrax.simulation.deterministic import run_interactive
 from hydrax.tasks.pendulum import Pendulum
 
 """
@@ -18,23 +18,27 @@ task = Pendulum()
 # Set the controller based on command-line arguments
 if len(sys.argv) == 1 or sys.argv[1] == "ps":
     print("Running predictive sampling")
-    ctrl = PredictiveSampling(task, num_samples=16, noise_level=0.1)
+    ctrl = PredictiveSampling(task, num_samples=32, noise_level=0.1)
 elif sys.argv[1] == "mppi":
     print("Running MPPI")
-    ctrl = MPPI(task, num_samples=16, noise_level=0.1, temperature=0.1)
+    ctrl = MPPI(task, num_samples=32, noise_level=0.1, temperature=0.1)
 else:
     print("Usage: python pendulum.py [ps|mppi]")
     sys.exit(1)
 
 # Define the model used for simulation
 mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/pendulum/scene.xml")
-start_state = np.array([0.0, 0.0])
+
+# Set the initial state
+mj_data = mujoco.MjData(mj_model)
+mj_data.qpos[:] = np.array([0.0])
+mj_data.qvel[:] = np.array([0.0])
 
 # Run the interactive simulation
 run_interactive(
-    mj_model,
     ctrl,
-    start_state,
+    mj_model,
+    mj_data,
     frequency=50,
     fixed_camera_id=0,
     show_traces=True,

--- a/examples/walker.py
+++ b/examples/walker.py
@@ -1,11 +1,10 @@
 import sys
 
 import mujoco
-import numpy as np
 
 from hydrax import ROOT
 from hydrax.algs import MPPI, PredictiveSampling
-from hydrax.mpc import run_interactive
+from hydrax.simulation.deterministic import run_interactive
 from hydrax.tasks.walker import Walker
 
 """
@@ -30,13 +29,13 @@ else:
 mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/walker/scene.xml")
 mj_model.opt.timestep = 0.005
 mj_model.opt.iterations = 50
-start_state = np.zeros(mj_model.nq + mj_model.nv)
+mj_data = mujoco.MjData(mj_model)
 
 # Run the interactive simulation
 run_interactive(
-    mj_model,
     ctrl,
-    start_state,
+    mj_model,
+    mj_data,
     frequency=50,
     fixed_camera_id=0,
     show_traces=True,

--- a/hydrax/models/cube/leap_rh.xml
+++ b/hydrax/models/cube/leap_rh.xml
@@ -11,7 +11,7 @@ Adopted from https://github.com/alberthli/mujoco_mpc/blob/leap-hardware/mjpc/tas
     iterations="4"
     ls_iterations="10"
   >
-    <flag eulerdamp="disable" />
+    <flag eulerdamp="disable"/>
   </option>
 
   <custom>
@@ -40,17 +40,17 @@ Adopted from https://github.com/alberthli/mujoco_mpc/blob/leap-hardware/mjpc/tas
   <!-- defaults -->
   <default>
     <!-- friction and fingertip geoms -->
-    <geom friction="0.2" solref="0.01 1.5" solimp="0.0 0.95 0.001" />
+    <geom friction="0.2" solref="0.01 1.5" solimp="0.0 0.95 0.001" contype="1"/>
     <default class="cube">
-      <geom friction="0.3 0.05 0.01" />
+      <geom friction="0.3 0.05 0.01" conaffinity="1"/>
     </default>
     <default class="tip">
       <geom type="capsule" size="0.012 0.008" pos="0 -0.03 0.015" quat="0.717 0.717 0 0"
-        friction="0.7 0.05 0.0002" />
+        friction="0.7 0.05 0.0002"/>
     </default>
     <default class="thumb_tip">
       <geom type="capsule" size="0.012 0.008" pos="0.0 -0.04 -0.015" quat="0.717 0.717 0 0"
-        friction="0.7 0.05 0.0002" />
+        friction="0.7 0.05 0.0002"/>
     </default>
 
     <!-- actuators -->

--- a/hydrax/models/cube/leap_rh.xml
+++ b/hydrax/models/cube/leap_rh.xml
@@ -40,17 +40,17 @@ Adopted from https://github.com/alberthli/mujoco_mpc/blob/leap-hardware/mjpc/tas
   <!-- defaults -->
   <default>
     <!-- friction and fingertip geoms -->
-    <geom friction="0.2" solref="0.01 1.5" solimp="0.0 0.95 0.001" contype="1"/>
+    <geom friction="0.2" solref="0.01 1.5" solimp="0.0 0.95 0.001" />
     <default class="cube">
-      <geom friction="0.3 0.05 0.01" conaffinity="1"/>
+      <geom friction="0.3 0.05 0.01" conaffinity="2" />
     </default>
     <default class="tip">
       <geom type="capsule" size="0.012 0.008" pos="0 -0.03 0.015" quat="0.717 0.717 0 0"
-        friction="0.7 0.05 0.0002"/>
+        friction="0.7 0.05 0.0002" />
     </default>
     <default class="thumb_tip">
       <geom type="capsule" size="0.012 0.008" pos="0.0 -0.04 -0.015" quat="0.717 0.717 0 0"
-        friction="0.7 0.05 0.0002"/>
+        friction="0.7 0.05 0.0002" />
     </default>
 
     <!-- actuators -->
@@ -396,8 +396,8 @@ Adopted from https://github.com/alberthli/mujoco_mpc/blob/leap-hardware/mjpc/tas
             <inertial pos="0 0 -0.0070806" quat="0.707107 0.707107 0 0" mass="0.003"
               diaginertia="6.1932e-07 5.351e-07 2.1516e-07" />
             <joint name="th_axl" class="thumb_axl" />
-            <geom name="th_bs_collision_1" pos="0.01196 0 -0.0158" quat="0.707109 0.707105 0 0"
-              type="mesh" contype="0" conaffinity="0" group="1" density="0" mesh="thumb_base" />
+            <!-- <geom name="th_bs_collision_1" pos="0.01196 0 -0.0158" quat="0.707109 0.707105 0 0"
+              type="mesh" contype="0" conaffinity="0" group="1" density="0" mesh="thumb_base" /> -->
             <!-- <geom name="th_bs_collision_2" size="0.009 0.0165 0.002" pos="0 0 -0.0015"
             type="box"/>
             <geom name="th_bs_collision_3" size="0.007 0.002 0.01" pos="0 -0.015 -0.013" type="box"/>

--- a/hydrax/models/cube/reorientation_cube.xml
+++ b/hydrax/models/cube/reorientation_cube.xml
@@ -21,7 +21,7 @@
     <light pos="0 0 1" />
     <body name="cube" pos="0.11 0.0 0.1" quat="1 0 0 0">
       <freejoint />
-      <geom name="cube" type="box" size=".035 .035 .035" mass=".108" material="cube" />
+      <geom class="cube" name="cube" type="box" size=".035 .035 .035" mass=".108" material="cube" />
       <site name="cube_center" pos="0 0 0" />
     </body>
   </worldbody>

--- a/hydrax/models/cube/scene.xml
+++ b/hydrax/models/cube/scene.xml
@@ -33,7 +33,7 @@
   <!-- Ground and light -->
   <worldbody>
     <light pos="0 0 3" dir="0 0 -1" directional="false" />
-    <geom name="floor" pos="0 0 -0.25" size="0 0 .125" type="plane" material="groundplane" />
+    <!-- <geom name="floor" pos="0 0 -0.25" size="0 0 .125" type="plane" material="groundplane" contype="2"/> -->
   </worldbody>
 
   <!-- Sensors for the cube -->

--- a/hydrax/models/cube/scene.xml
+++ b/hydrax/models/cube/scene.xml
@@ -33,7 +33,7 @@
   <!-- Ground and light -->
   <worldbody>
     <light pos="0 0 3" dir="0 0 -1" directional="false" />
-    <!-- <geom name="floor" pos="0 0 -0.25" size="0 0 .125" type="plane" material="groundplane" contype="2"/> -->
+    <geom name="floor" pos="0 0 -1.25" size="10 10 1" type="box" material="groundplane" contype="2" conaffinity="2"/>
   </worldbody>
 
   <!-- Sensors for the cube -->

--- a/hydrax/simulation/asynchronous.py
+++ b/hydrax/simulation/asynchronous.py
@@ -1,0 +1,61 @@
+from typing import Any, Callable, Tuple
+import jax
+import time
+from multiprocessing import Process, shared_memory, Lock, Event, Queue
+import numpy as np
+import jax.numpy as jnp
+
+import mujoco
+import mujoco.viewer
+from mujoco import mjx
+
+from hydrax.alg_base import SamplingBasedController
+from hydrax.task_base import Task
+
+
+"""
+Utilities for asynchronous simulation, with the simulator and controller running
+in separate processes. The controller runs as fast as possible, while the 
+simulator runs in real time. 
+
+This is more realistic than deterministic simulation, but supports a limited set
+of features (e.g., no trace visualization, zero-order-hold interpolation only).
+"""
+
+class SharedMemoryNumpyArray:
+    """Helper class to store a numpy array in shared memory."""
+
+    def __init__(self, arr: np.ndarray):
+        """Create a shared memory numpy array.
+
+        Args:
+            arr: The numpy array to store in shared memory. Size and dtype must
+                 be fixed.
+        """
+        self.shm = shared_memory.SharedMemory(create=True, size=arr.nbytes)
+        self.data = np.ndarray(arr.shape, dtype=arr.dtype, buffer=self.shm.buf)
+        self.data[:] = arr[:]
+        self.lock = Lock()
+
+    def __getitem__(self, key):
+        """Get an item from the shared array."""
+        return self.data[key]
+
+    def __setitem__(self, key, value):
+        """Set an item in the shared array."""
+        with self.lock:
+            self.data[key] = value
+
+    def __str__(self):
+        """Return the string representation of the shared array."""
+        return str(self.data)
+
+    def __del__(self):
+        """Clean up the shared memory on deletion."""
+        self.shm.close()
+        self.shm.unlink()
+
+    @property
+    def shape(self):
+        """Return the shape of the shared array."""
+        return self.shared_arr.shape

--- a/hydrax/simulation/asynchronous.py
+++ b/hydrax/simulation/asynchronous.py
@@ -1,26 +1,25 @@
-from typing import Any, Callable, Tuple
-import jax
 import time
-from multiprocessing import Process, shared_memory, Lock, Event, Queue
-import numpy as np
-import jax.numpy as jnp
+from multiprocessing import Event, Lock, shared_memory
+from typing import Callable, Tuple
 
+import jax
+import jax.numpy as jnp
 import mujoco
 import mujoco.viewer
+import numpy as np
 from mujoco import mjx
 
 from hydrax.alg_base import SamplingBasedController
-from hydrax.task_base import Task
-
 
 """
 Utilities for asynchronous simulation, with the simulator and controller running
-in separate processes. The controller runs as fast as possible, while the 
-simulator runs in real time. 
+in separate processes. The controller runs as fast as possible, while the
+simulator runs in real time.
 
 This is more realistic than deterministic simulation, but supports a limited set
 of features (e.g., no trace visualization, zero-order-hold interpolation only).
 """
+
 
 class SharedMemoryNumpyArray:
     """Helper class to store a numpy array in shared memory."""
@@ -37,25 +36,126 @@ class SharedMemoryNumpyArray:
         self.data[:] = arr[:]
         self.lock = Lock()
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: int) -> np.ndarray:
         """Get an item from the shared array."""
         return self.data[key]
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: int, value: np.ndarray) -> None:
         """Set an item in the shared array."""
         with self.lock:
             self.data[key] = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return the string representation of the shared array."""
         return str(self.data)
 
-    def __del__(self):
+    def __del__(self) -> None:
         """Clean up the shared memory on deletion."""
         self.shm.close()
         self.shm.unlink()
 
     @property
-    def shape(self):
+    def shape(self) -> Tuple[int, ...]:
         """Return the shape of the shared array."""
         return self.shared_arr.shape
+
+
+class SharedMemoryMujocoData:
+    """Helper class for passing mujoco data between concurrent processes."""
+
+    def __init__(self, mj_data: mujoco.MjData):
+        """Create shared memory objects for state and control data.
+
+        Note that this does not copy the full mj_data object, only those fields
+        that we want to share between the simulator and controller.
+
+        Args:
+            mj_data: The mujoco data object to store in shared memory.
+        """
+        # N.B. we use float32 to match JAX's default precision
+        self.qpos = SharedMemoryNumpyArray(
+            np.array(mj_data.qpos, dtype=np.float32)
+        )
+        self.qvel = SharedMemoryNumpyArray(
+            np.array(mj_data.qvel, dtype=np.float32)
+        )
+        self.ctrl = SharedMemoryNumpyArray(
+            np.zeros(mj_data.ctrl.shape, dtype=np.float32)
+        )
+
+        if len(mj_data.mocap_pos) > 0:
+            self.mocap_pos = SharedMemoryNumpyArray(
+                np.array(mj_data.mocap_pos, dtype=np.float32)
+            )
+            self.mocap_quat = SharedMemoryNumpyArray(
+                np.array(mj_data.mocap_quat, dtype=np.float32)
+            )
+        else:
+            # We need non-empty arrays, even if they are not used
+            self.mocap_pos = SharedMemoryNumpyArray(
+                np.zeros((3,), dtype=np.float32)
+            )
+            self.mocap_quat = SharedMemoryNumpyArray(
+                np.zeros((4,), dtype=np.float32)
+            )
+
+
+def controller(
+    setup_fn: Callable[[], SamplingBasedController],
+    shm_data: SharedMemoryMujocoData,
+    ready: Event,
+    finished: Event,
+) -> None:
+    """Run the controller, communicating with the simulator over shared memory.
+
+    Note: we need to create the controller within this process, otherwise
+    JAX will complain about sharing data across processes. That's why we take
+    a callable `setup_fn` to create the controller, rather than the controller
+    itself.
+
+    Args:
+        setup_fn: Function to set up the controller.
+        shm_data: Shared memory object for state and control action data.
+        ready: Shared flag for signaling that the controller is ready.
+        finished: Shared flag for stopping the simulation.
+    """
+    # Set up the controller
+    ctrl = setup_fn()
+    mjx_data = mjx.make_data(ctrl.task.model)
+    policy_params = ctrl.init_params()
+
+    # Jit the optimizer step, then signal that we're ready to go
+    print("Jitting controller...")
+    st = time.time()
+    jit_optimize = jax.jit(
+        lambda d, p: ctrl.optimize(d, p)[0], donate_argnums=(1,)
+    )
+    get_action = jax.jit(ctrl.get_action)
+    policy_params = jit_optimize(mjx_data, policy_params)
+    print(f"Time to jit: {time.time() - st}")
+
+    # Signal that we're ready to start
+    ready.set()
+
+    while not finished.is_set():
+        st = time.time()
+
+        # Set the start state for the controller, reading the lastest state info
+        # from shared memory
+        mjx_data = mjx_data.replace(
+            qpos=jnp.array(shm_data.qpos.data),
+            qvel=jnp.array(shm_data.qvel.data),
+            mocap_pos=jnp.array(shm_data.mocap_pos.data),
+            mocap_quat=jnp.array(shm_data.mocap_quat.data),
+        )
+
+        # Do a planning step
+        policy_params = jit_optimize(mjx_data, policy_params)
+
+        # Send the action to the simulator
+        shm_data.ctrl[:] = np.array(
+            get_action(policy_params, 0.0), dtype=np.float32
+        )
+
+        # Print the current planning frequency
+        print(f"Controller running at {1/(time.time() - st):.2f} Hz")

--- a/hydrax/simulation/asynchronous.py
+++ b/hydrax/simulation/asynchronous.py
@@ -190,17 +190,17 @@ def run_simulator(
             start_time = time.time()
 
             # Write the latest state to shared memory for the controller to read
-            shm_data.qpos[:] = np.copy(mj_data.qpos)
-            shm_data.qvel[:] = np.copy(mj_data.qvel)
+            shm_data.qpos[:] = mj_data.qpos
+            shm_data.qvel[:] = mj_data.qvel
 
             if len(mj_data.mocap_pos) > 0:
-                shm_data.mocap_pos[:] = np.copy(mj_data.mocap_pos)
-                shm_data.mocap_quat[:] = np.copy(mj_data.mocap_quat)
+                shm_data.mocap_pos[:] = mj_data.mocap_pos
+                shm_data.mocap_quat[:] = mj_data.mocap_quat
 
             # Read the lastest control values from shared memory
             # TODO: actually query the spline rather than assuming zero-order
             # hold and a sufficiently high control rate
-            mj_data.ctrl[:] = np.copy(shm_data.ctrl[:])
+            mj_data.ctrl[:] = shm_data.ctrl[:]
 
             # Step the simulation
             mujoco.mj_step(mj_model, mj_data)

--- a/hydrax/simulation/asynchronous.py
+++ b/hydrax/simulation/asynchronous.py
@@ -116,6 +116,12 @@ def run_controller(
     mjx_data = mjx.make_data(ctrl.task.model)
     policy_params = ctrl.init_params()
 
+    # Print out some planning horizon information
+    print(
+        f"Planning with {ctrl.task.planning_horizon} steps "
+        f"over a {ctrl.task.planning_horizon * ctrl.task.dt} second horizon."
+    )
+
     # Jit the optimizer step, then signal that we're ready to go
     print("Jitting controller...")
     st = time.time()

--- a/hydrax/simulation/deterministic.py
+++ b/hydrax/simulation/deterministic.py
@@ -10,11 +10,16 @@ from mujoco import mjx
 
 from hydrax.alg_base import SamplingBasedController
 
+"""
+Tools for deterministic (synchronous) simulation, with the simulator and
+controller running one after the other in the same thread.
+"""
+
 
 def run_interactive(
-    mj_model: mujoco.MjModel,
     controller: SamplingBasedController,
-    start_state: np.ndarray,
+    mj_model: mujoco.MjModel,
+    mj_data: mujoco.MjData,
     frequency: float,
     fixed_camera_id: int = None,
     show_traces: bool = True,
@@ -24,29 +29,27 @@ def run_interactive(
 ) -> None:
     """Run an interactive simulation with the MPC controller.
 
+    This is a deterministic simulation, with the controller and simulation
+    running in the same thread. This is useful for repeatability, but is less
+    realistic than asynchronous simulation.
+
+    Note: the actual control frequency may be slightly different than what is
+    requested, because the control period must be an integer multiple of the
+    simulation time step.
+
     Args:
-        mj_model: The MuJoCo model for the system to use for simulation. Could
-                  be slightly different from the model used by the controller.
         controller: The controller instance, which includes the task
                     (e.g., model, cost) definition.
-        start_state: The initial state x₀ = [q₀, v₀] of the system.
+        mj_model: The MuJoCo model for the system to use for simulation. Could
+                  be slightly different from the model used by the controller.
+        mj_data: A MuJoCo data object containing the initial system state.
         frequency: The requested control frequency (Hz) for replanning.
         fixed_camera_id: The camera ID to use for the fixed camera view.
         show_traces: Whether to show traces for the site positions.
         max_traces: The maximum number of traces to show at once.
         trace_width: The width of the trace lines (in pixels).
         trace_color: The RGBA color of the trace lines.
-
-    Note: the actual control frequency may be slightly different than what is
-    requested, because the control period must be an integer multiple of the
-    simulation time step.
     """
-    # Set the initial state
-    assert len(start_state) == mj_model.nq + mj_model.nv
-    mj_data = mujoco.MjData(mj_model)
-    mj_data.qpos[:] = start_state[: mj_model.nq]
-    mj_data.qvel[:] = start_state[mj_model.nq :]
-
     # Report the planning horizon in seconds for debugging
     num_steps = controller.task.planning_horizon - 1
     print(
@@ -75,6 +78,7 @@ def run_interactive(
     jit_optimize = jax.jit(controller.optimize, donate_argnums=(1,))
 
     # Warm-up the controller
+    print("Jitting the controller...")
     st = time.time()
     policy_params, rollouts = jit_optimize(mjx_data, policy_params)
     print(f"Time to jit: {time.time() - st:.3f} seconds")
@@ -153,3 +157,6 @@ def run_interactive(
                 f"Realtime rate: {rtr:.2f}, plan time: {plan_time:.4f}s",
                 end="\r",
             )
+
+    # Preserve the last printout
+    print("")

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -62,8 +62,8 @@ def test_controller() -> None:
 def manual_test_interactive() -> None:
     """Test running an interactive simulation.
 
-    Note that this does not as a normal test, only when called directly, because
-    this will open a window and block the test suite.
+    Note that this does not run as a normal test, only when called directly. It
+    opens a window and would block the test suite.
     """
     mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/pendulum/scene.xml")
     mj_data = mujoco.MjData(mj_model)

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -32,8 +32,13 @@ def test_shared_nparray() -> None:
     assert np.all(shared[1:] == original[1:])
 
 
-def test_controller() -> None:
-    """Test running the controller in a separate process."""
+def manual_test_controller() -> None:
+    """Test running the controller in a separate process.
+
+    This does not run as a normal test, only when called directly. This is
+    running any jax code outside the controller results in a `os.fork() is
+    incompatible with multithreaded code, and JAX is multithreaded` error.
+    """
     mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/pendulum/scene.xml")
     mj_data = mujoco.MjData(mj_model)
 
@@ -78,5 +83,5 @@ def manual_test_interactive() -> None:
 
 if __name__ == "__main__":
     test_shared_nparray()
-    test_controller()
+    manual_test_controller()
     manual_test_interactive()

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,7 +1,17 @@
-import numpy as np
-from multiprocessing import Process
+import time
+from multiprocessing import Event, Process
 
-from hydrax.simulation.asynchronous import SharedMemoryNumpyArray
+import mujoco
+import numpy as np
+
+from hydrax import ROOT
+from hydrax.algs.predictive_sampling import PredictiveSampling
+from hydrax.simulation.asynchronous import (
+    SharedMemoryMujocoData,
+    SharedMemoryNumpyArray,
+    controller,
+)
+from hydrax.tasks.pendulum import Pendulum
 
 
 def test_shared_nparray() -> None:
@@ -21,5 +31,33 @@ def test_shared_nparray() -> None:
     assert np.all(shared[1:] == original[1:])
 
 
+def test_controller() -> None:
+    """Test running the controller in a separate process."""
+    mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/pendulum/scene.xml")
+    mj_data = mujoco.MjData(mj_model)
+
+    def _setup_fn() -> PredictiveSampling:
+        """Set up the controller."""
+        task = Pendulum()
+        return PredictiveSampling(task, num_samples=8, noise_level=0.1)
+
+    shared_mjdata = SharedMemoryMujocoData(mj_data)
+    ready = Event()
+    finished = Event()
+    proc = Process(
+        target=controller, args=(_setup_fn, shared_mjdata, ready, finished)
+    )
+
+    proc.start()
+    time.sleep(5)
+    finished.set()
+    proc.join()
+
+    assert not proc.is_alive()
+    assert ready.is_set()
+    assert finished.is_set()
+
+
 if __name__ == "__main__":
     test_shared_nparray()
+    test_controller()

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -1,0 +1,25 @@
+import numpy as np
+from multiprocessing import Process
+
+from hydrax.simulation.asynchronous import SharedMemoryNumpyArray
+
+
+def test_shared_nparray() -> None:
+    """Test reading and writing a shared-memory numpy array."""
+    original = np.array([0.0, 1.0, 2.0, 3.0])
+    shared = SharedMemoryNumpyArray(original)
+
+    def _write(shared: SharedMemoryNumpyArray) -> None:
+        shared[0] = 4.0
+
+    proc = Process(target=_write, args=(shared,))
+    proc.start()
+    proc.join()
+
+    assert shared[0] == 4.0
+    assert original[0] == 0.0
+    assert np.all(shared[1:] == original[1:])
+
+
+if __name__ == "__main__":
+    test_shared_nparray()


### PR DESCRIPTION
Implements a basic asynchronous simulation, with state and control info passed between separate simulator and controller processes via shared memory. 

This eliminates a good deal of the device transfer overhead noted in #13 by (1) not trying to visualize rollout traces and (2) assuming zero-order-hold interpolation and a control frequency faster than the time between knot points.