### PR TITLE
Bump JAX version to 0.4.35

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.6.9
+    rev: v0.7.1
     hooks:
     -   id: ruff
         types_or: [ python, pyi, jupyter ]

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ conda activate hydrax
 Install the package and dependencies:
 
 ```bash
-pip install -e . --find-links https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+pip install -e .
 ```
 
 (Optional) set up pre-commit hooks:

--- a/environment.yml
+++ b/environment.yml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - cuda
   - cudnn
-  - python=3.11
+  - python=3.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,23 +8,21 @@ version = "0.0.1"
 description = "Sampling-based model predictive control on GPU with JAX/MJX"
 readme = "README.md"
 license = {text="MIT"}
-requires-python = ">=3.11.0"
+requires-python = ">=3.12.0"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python",
 ]
 dependencies = [
-    "jax[cuda12_local]==0.4.28",
-    "nvidia-cudnn-cu12==8.9.2.26",
-    "jaxlib==0.4.28",
-    "flax>=0.8.1",
-    "pytest>=7.4.2",
-    "ruff>=0.4.10",
-    "pre-commit>=3.7.1",
-    "matplotlib>=3.8.3",
-    "mujoco>=3.2.4",
-    "mujoco-mjx>=3.2.4",
-    "evosax>=0.1.6",
+    "jax[cuda12]==0.4.35",
+    "flax==0.10.0",
+    "pytest==8.3.3",
+    "ruff==0.7.1",
+    "pre-commit==4.0.1",
+    "matplotlib==3.9.2",
+    "mujoco==3.2.4",
+    "mujoco-mjx==3.2.4",
+    "evosax==0.1.6",
 ]
 
 [tool.ruff]

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -57,7 +57,8 @@ def test_controller() -> None:
     )
 
     proc.start()
-    time.sleep(5)
+    ready.wait()
+    time.sleep(1)
     finished.set()
     proc.join()
 


### PR DESCRIPTION
Updates JAX to the latest version. This simplifies the installation process, as well as giving us access to the latest and greatest.

Also updates to python 3.12 instead of 3.11 - you may need to rebuild the conda env.