### PR TITLE
Store the mujoco model in task

### DIFF
--- a/examples/cart_pole.py
+++ b/examples/cart_pole.py
@@ -1,6 +1,5 @@
 import mujoco
 
-from hydrax import ROOT
 from hydrax.algs import PredictiveSampling
 from hydrax.simulation.deterministic import run_interactive
 from hydrax.tasks.cart_pole import CartPole
@@ -16,7 +15,7 @@ task = CartPole()
 ctrl = PredictiveSampling(task, num_samples=128, noise_level=0.3)
 
 # Define the model used for simulation
-mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/cart_pole/scene.xml")
+mj_model = task.mj_model
 mj_data = mujoco.MjData(mj_model)
 mj_data.qpos[1] = 3.14  # Set the pole to be facing down
 

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -3,7 +3,6 @@ import sys
 import evosax
 import mujoco
 
-from hydrax import ROOT
 from hydrax.algs import CEM, MPPI, Evosax, PredictiveSampling
 from hydrax.simulation.deterministic import run_interactive
 from hydrax.tasks.cube import CubeRotation
@@ -57,7 +56,7 @@ else:
     sys.exit(1)
 
 # Define the model used for simulation
-mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/cube/scene.xml")
+mj_model = task.mj_model
 mj_data = mujoco.MjData(mj_model)
 
 # Run the interactive simulation

--- a/examples/cube_async.py
+++ b/examples/cube_async.py
@@ -1,6 +1,5 @@
 import mujoco
 
-from hydrax import ROOT
 from hydrax.algs import PredictiveSampling
 from hydrax.simulation.asynchronous import run_interactive
 from hydrax.tasks.cube import CubeRotation
@@ -22,7 +21,7 @@ if __name__ == "__main__":
     )
 
     # Define the model used for simulation (with more realistic parameters)
-    mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/cube/scene.xml")
+    mj_model = task.mj_model
     mj_model.opt.timestep = 0.005
     mj_model.opt.iterations = 100
     mj_model.opt.ls_iterations = 50

--- a/examples/humanoid.py
+++ b/examples/humanoid.py
@@ -1,6 +1,5 @@
 import mujoco
 
-from hydrax import ROOT
 from hydrax.algs import PredictiveSampling
 from hydrax.simulation.deterministic import run_interactive
 from hydrax.tasks.humanoid import Humanoid
@@ -16,7 +15,7 @@ task = Humanoid()
 ctrl = PredictiveSampling(task, num_samples=128, noise_level=0.2)
 
 # Define the model used for simulation
-mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/g1/scene.xml")
+mj_model = task.mj_model
 
 # Set the initial state
 mj_data = mujoco.MjData(mj_model)

--- a/examples/particle.py
+++ b/examples/particle.py
@@ -3,7 +3,6 @@ import sys
 import evosax
 import mujoco
 
-from hydrax import ROOT
 from hydrax.algs import MPPI, Evosax, PredictiveSampling
 from hydrax.risk import WorstCase
 from hydrax.simulation.deterministic import run_interactive
@@ -64,7 +63,7 @@ else:
     sys.exit(1)
 
 # Define the model used for simulation
-mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/particle/scene.xml")
+mj_model = task.mj_model
 mj_data = mujoco.MjData(mj_model)
 
 # Run the interactive simulation

--- a/examples/pendulum.py
+++ b/examples/pendulum.py
@@ -3,7 +3,6 @@ import sys
 import mujoco
 import numpy as np
 
-from hydrax import ROOT
 from hydrax.algs import MPPI, PredictiveSampling
 from hydrax.simulation.deterministic import run_interactive
 from hydrax.tasks.pendulum import Pendulum
@@ -27,7 +26,7 @@ else:
     sys.exit(1)
 
 # Define the model used for simulation
-mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/pendulum/scene.xml")
+mj_model = task.mj_model
 
 # Set the initial state
 mj_data = mujoco.MjData(mj_model)

--- a/examples/walker.py
+++ b/examples/walker.py
@@ -2,7 +2,6 @@ import sys
 
 import mujoco
 
-from hydrax import ROOT
 from hydrax.algs import MPPI, PredictiveSampling
 from hydrax.simulation.deterministic import run_interactive
 from hydrax.tasks.walker import Walker
@@ -26,7 +25,7 @@ else:
     sys.exit(1)
 
 # Define the model used for simulation
-mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/walker/scene.xml")
+mj_model = task.mj_model
 mj_model.opt.timestep = 0.005
 mj_model.opt.iterations = 50
 mj_data = mujoco.MjData(mj_model)

--- a/hydrax/task_base.py
+++ b/hydrax/task_base.py
@@ -39,6 +39,7 @@ class Task(ABC):
               Newton iterations, etc., are set in the model itself.
         """
         assert isinstance(mj_model, mujoco.MjModel)
+        self.mj_model = mj_model
         self.model = mjx.put_model(mj_model)
         self.planning_horizon = planning_horizon
         self.sim_steps_per_control_step = sim_steps_per_control_step


### PR DESCRIPTION
Keeps the (CPU) mujoco model around in the task, rather than ditching it after constructing the mjx model. 

This makes it a bit easier to run simulations, since we don't have to dredge the original XML description back up. We can still modify this mj_model to simulate model mismatch. 