### PR TITLE
Internal simplifications

### DIFF
--- a/hydrax/simulation/deterministic.py
+++ b/hydrax/simulation/deterministic.py
@@ -132,8 +132,8 @@ def run_interactive(
                                 viewer.user_scn.geoms[ii],
                                 mujoco.mjtGeom.mjGEOM_LINE,
                                 trace_width,
-                                rollouts.trace_sites[0, i, j, k],
-                                rollouts.trace_sites[0, i, j + 1, k],
+                                rollouts.trace_sites[i, j, k],
+                                rollouts.trace_sites[i, j + 1, k],
                             )
                             ii += 1
 

--- a/hydrax/task_base.py
+++ b/hydrax/task_base.py
@@ -89,18 +89,6 @@ class Task(ABC):
         """
         pass
 
-    def get_obs(self, state: mjx.Data) -> jax.Array:
-        """Get the observation vector at the current time step.
-
-        Args:
-            state: The current state xₜ.
-
-        Returns:
-            The observation vector yₜ.
-        """
-        # The default is to return the full state as the observation
-        return jnp.concatenate([state.qpos, state.qvel])
-
     def get_trace_sites(self, state: mjx.Data) -> jax.Array:
         """Get the positions of the trace sites at the current time step.
 

--- a/hydrax/tasks/cube.py
+++ b/hydrax/tasks/cube.py
@@ -83,12 +83,3 @@ class CubeRotation(Task):
         """Randomly shift the measured configurations."""
         shift = 0.005 * jax.random.normal(rng, (self.model.nq,))
         return {"qpos": data.qpos + shift}
-
-    def get_obs(self, state: mjx.Data) -> jax.Array:
-        """Observe the hand position, cube pose relative to target, and vels."""
-        hand_qpos = state.qpos[7:]
-        cube_position_err = self._get_cube_position_err(state)
-        cube_orientation_err = self._get_cube_orientation_err(state)
-        return jnp.concatenate(
-            [cube_position_err, cube_orientation_err, hand_qpos, state.qvel]
-        )

--- a/hydrax/tasks/particle.py
+++ b/hydrax/tasks/particle.py
@@ -56,9 +56,3 @@ class Particle(Task):
         """Randomly shift the measured particle position."""
         shift = jax.random.uniform(rng, (2,), minval=-0.01, maxval=0.01)
         return {"qpos": data.qpos + shift}
-
-    def get_obs(self, state: mjx.Data) -> jax.Array:
-        """Observe the position relative to the target and the velocity."""
-        pos = state.site_xpos[self.pointmass_id, 0:2] - state.mocap_pos[0, 0:2]
-        vel = state.qvel[:]
-        return jnp.concatenate([pos, vel])

--- a/hydrax/tasks/walker.py
+++ b/hydrax/tasks/walker.py
@@ -72,7 +72,3 @@ class Walker(Task):
             self._get_torso_velocity(state) - self.target_velocity
         )
         return 10.0 * height_cost + 3.0 * orientation_cost + 1.0 * velocity_cost
-
-    def get_obs(self, state: mjx.Data) -> jax.Array:
-        """Observe everything in the state except the horizontal position."""
-        return jnp.concatenate([jnp.delete(state.qpos, 1), state.qvel])

--- a/tests/test_alg_base.py
+++ b/tests/test_alg_base.py
@@ -7,11 +7,10 @@ def test_traj() -> None:
     """Make sure we can define a Trajectory object."""
     batch, horizon = 5, 10
     U = jnp.zeros((batch, horizon, 3))
-    Y = jnp.zeros((batch, horizon + 1, 4))
     J = jnp.zeros((batch, horizon + 1))
     P = jnp.zeros((batch, horizon + 1, 0, 3))
 
-    traj = Trajectory(controls=U, costs=J, observations=Y, trace_sites=P)
+    traj = Trajectory(controls=U, costs=J, trace_sites=P)
     assert len(traj) == horizon
 
 

--- a/tests/test_cart_pole.py
+++ b/tests/test_cart_pole.py
@@ -19,9 +19,6 @@ def test_cart_pole() -> None:
     assert phi.shape == ()
     assert phi >= 0.0
 
-    y = task.get_obs(state)
-    assert y.shape == (4,)
-
 
 if __name__ == "__main__":
     test_cart_pole()

--- a/tests/test_cube.py
+++ b/tests/test_cube.py
@@ -68,12 +68,6 @@ def test_task() -> None:
     assert cube_orientation.shape == (3,)
     assert jnp.allclose(cube_orientation, jnp.array([-jnp.pi, 0.0, 0.0]))
 
-    # Test observation
-    obs = task.get_obs(state)
-    assert jnp.all(obs[0:3] == cube_position)
-    assert jnp.all(obs[3:6] == cube_orientation)
-    assert obs.shape == (6 + 16 + task.model.nv,)
-
 
 if __name__ == "__main__":
     test_mjx_model()

--- a/tests/test_dr.py
+++ b/tests/test_dr.py
@@ -48,7 +48,6 @@ def test_opt() -> None:
     # (randomizations, samples, timestep, ...)
     assert rollouts.costs.shape == (3, 11, 6)
     assert rollouts.controls.shape == (3, 11, 5, 2)
-    assert rollouts.observations.shape == (3, 11, 6, 4)
 
     # Check the updated parameters
     assert params.mean.shape == (5, 2)

--- a/tests/test_dr.py
+++ b/tests/test_dr.py
@@ -44,17 +44,12 @@ def test_opt() -> None:
     # Run an optimization step
     params, rollouts = ctrl.optimize(state, params)
 
-    # Check the rollout shapes. Should be
-    # (randomizations, samples, timestep, ...)
-    assert rollouts.costs.shape == (3, 11, 6)
-    assert rollouts.controls.shape == (3, 11, 5, 2)
+    # Check the rollout shapes. Should be still be (samples, timestep, ...)
+    assert rollouts.costs.shape == (11, 6)
+    assert rollouts.controls.shape == (11, 5, 2)
 
     # Check the updated parameters
     assert params.mean.shape == (5, 2)
-
-    # Check that the rollout costs are different across different models
-    costs = jnp.sum(rollouts.costs, axis=(1, 2))
-    assert not jnp.allclose(costs[0], costs[1])
 
 
 if __name__ == "__main__":

--- a/tests/test_mppi.py
+++ b/tests/test_mppi.py
@@ -23,7 +23,7 @@ def test_open_loop() -> None:
         params, _ = jit_opt(state, params)
 
     # Roll out the solution, check that it's good enough
-    final_rollout = jax.jit(opt.eval_rollouts)(
+    states, final_rollout = jax.jit(opt.eval_rollouts)(
         task.model, state, params.mean[None]
     )
     total_cost = jnp.sum(final_rollout.costs[0])
@@ -32,15 +32,15 @@ def test_open_loop() -> None:
     if __name__ == "__main__":
         # Plot the solution
         _, ax = plt.subplots(3, 1, sharex=True)
-        times = jnp.arange(task.planning_horizon + 1) * task.dt
+        times = jnp.arange(task.planning_horizon) * task.dt
 
-        ax[0].plot(times, final_rollout.observations[0, :, 0])
+        ax[0].plot(times, states.qpos[0, :, 0])
         ax[0].set_ylabel(r"$\theta$")
 
-        ax[1].plot(times, final_rollout.observations[0, :, 1])
+        ax[1].plot(times, states.qvel[0, :, 0])
         ax[1].set_ylabel(r"$\dot{\theta}$")
 
-        ax[2].step(times[0:-1], final_rollout.controls[0], where="post")
+        ax[2].step(times, final_rollout.controls[0], where="post")
         ax[2].axhline(-1.0, color="black", linestyle="--")
         ax[2].axhline(1.0, color="black", linestyle="--")
         ax[2].set_ylabel("u")

--- a/tests/test_mppi.py
+++ b/tests/test_mppi.py
@@ -11,7 +11,7 @@ def test_open_loop() -> None:
     """Use MPPI for open-loop pendulum swingup."""
     # Task and optimizer setup
     task = Pendulum()
-    opt = MPPI(task, num_samples=32, noise_level=0.1, temperature=0.1)
+    opt = MPPI(task, num_samples=32, noise_level=0.1, temperature=0.01)
     jit_opt = jax.jit(opt.optimize)
 
     # Initialize the system state and policy parameters

--- a/tests/test_particle.py
+++ b/tests/test_particle.py
@@ -24,10 +24,6 @@ def test_particle() -> None:
     assert phi.shape == ()
     assert phi > 0.0
 
-    y = task.get_obs(state)
-    assert y.shape == (4,)
-    assert y[1] == -0.1
-
 
 if __name__ == "__main__":
     test_particle()

--- a/tests/test_pendulum.py
+++ b/tests/test_pendulum.py
@@ -19,9 +19,6 @@ def test_pendulum() -> None:
     assert phi.shape == ()
     assert phi > 0.0
 
-    y = task.get_obs(state)
-    assert y.shape == (2,)
-
 
 if __name__ == "__main__":
     test_pendulum()

--- a/tests/test_predictive_sampling.py
+++ b/tests/test_predictive_sampling.py
@@ -64,9 +64,9 @@ def test_open_loop() -> None:
         params, rollouts = jit_opt(state, params)
 
     # Pick the best rollout (first axis is for domain randomization, unused)
-    total_costs = jnp.sum(rollouts.costs[0], axis=1)
+    total_costs = jnp.sum(rollouts.costs, axis=1)
     best_idx = jnp.argmin(total_costs)
-    best_ctrl = rollouts.controls[0, best_idx]
+    best_ctrl = rollouts.controls[best_idx]
     assert total_costs[best_idx] <= 9.0
 
     states, _ = jax.jit(opt.eval_rollouts)(task.model, state, best_ctrl[None])

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -33,10 +33,6 @@ def test_walker() -> None:
     assert phi.shape == ()
     assert phi > 0.0
 
-    # Check observations
-    obs = task.get_obs(state)
-    assert obs.shape == (task.model.nq + task.model.nv - 1,)
-
 
 if __name__ == "__main__":
     test_walker()


### PR DESCRIPTION
Simplify some of the internal structure of the solver. 

- Observations are no longer recorded. Learning-based methods can compute their own observations from the `mjx.Data` returned by `eval_rollouts`
- Domain randomization is abstracted out to a separate method. This makes `SamplingBasedController.optimize` cleaner.
- Rollout costs returned by `optimize` have already been aggregated according to the given risk strategy. 