### PR TITLE
Tune the double cart-pole example

### DIFF
--- a/examples/double_cart_pole.py
+++ b/examples/double_cart_pole.py
@@ -13,7 +13,7 @@ is actuated, and the goal is to swing up the pendulum and balance it upright.
 task = DoubleCartPole()
 
 # Set up the controller
-ctrl = PredictiveSampling(task, num_samples=512, noise_level=0.3)
+ctrl = PredictiveSampling(task, num_samples=1024, noise_level=0.3)
 
 # Define the model used for simulation
 mj_model = task.mj_model

--- a/examples/double_cart_pole.py
+++ b/examples/double_cart_pole.py
@@ -18,7 +18,6 @@ ctrl = PredictiveSampling(task, num_samples=1024, noise_level=0.3)
 # Define the model used for simulation
 mj_model = task.mj_model
 mj_data = mujoco.MjData(mj_model)
-mj_data.qpos[1] = 3.14  # Set the pole to be facing down
 
 # Run the interactive simulation
 run_interactive(

--- a/examples/double_cart_pole.py
+++ b/examples/double_cart_pole.py
@@ -13,7 +13,7 @@ is actuated, and the goal is to swing up the pendulum and balance it upright.
 task = DoubleCartPole()
 
 # Set up the controller
-ctrl = PredictiveSampling(task, num_samples=512, noise_level=0.5)
+ctrl = PredictiveSampling(task, num_samples=512, noise_level=0.3)
 
 # Define the model used for simulation
 mj_model = task.mj_model

--- a/hydrax/models/double_cart_pole/double_cart_pole.xml
+++ b/hydrax/models/double_cart_pole/double_cart_pole.xml
@@ -11,7 +11,6 @@
   </default>
 
   <worldbody>
-    <light name="light" pos="0 0 8"/>
     <camera name="fixed" pos="0 -8 2" zaxis="0 -1 0"/>
     <camera name="lookatcart" mode="targetbody" target="cart" pos="0 -2 2"/>
     <geom name="rail1" type="capsule" pos="0  .07 2" zaxis="1 0 0" size="0.02 4"/>

--- a/hydrax/models/double_cart_pole/double_cart_pole.xml
+++ b/hydrax/models/double_cart_pole/double_cart_pole.xml
@@ -6,7 +6,7 @@
   <default>
     <default class="pole">
       <joint type="hinge" axis="0 1 0"  damping="2e-6"/>
-      <geom type="capsule" fromto="0 0 0 0 0 1" size="0.045" mass=".1"/>
+      <geom type="capsule" fromto="0 0 -1 0 0 0" size="0.045" mass=".1"/>
     </default>
   </default>
 
@@ -21,10 +21,10 @@
       <body name="pole_1" childclass="pole">
         <joint name="hinge_1" damping="1.0e-4"/>
         <geom name="pole_1"/>
-        <body name="pole_2" childclass="pole" pos="0 0 1">
+        <body name="pole_2" childclass="pole" pos="0 0 -1">
           <joint name="hinge_2" damping="1.0e-4"/>
           <geom name="pole_2"/>
-          <site name="tip" pos="0 0 1"/>
+          <site name="tip" pos="0 0 -1"/>
         </body>
       </body>
     </body>

--- a/hydrax/models/double_cart_pole/double_cart_pole.xml
+++ b/hydrax/models/double_cart_pole/double_cart_pole.xml
@@ -11,7 +11,7 @@
   </default>
 
   <worldbody>
-    <light name="light" pos="0 0 6"/>
+    <light name="light" pos="0 0 8"/>
     <camera name="fixed" pos="0 -8 2" zaxis="0 -1 0"/>
     <camera name="lookatcart" mode="targetbody" target="cart" pos="0 -2 2"/>
     <geom name="rail1" type="capsule" pos="0  .07 2" zaxis="1 0 0" size="0.02 4"/>

--- a/hydrax/models/double_cart_pole/scene.xml
+++ b/hydrax/models/double_cart_pole/scene.xml
@@ -16,7 +16,7 @@
   </asset>
 
   <worldbody>
-    <light pos="0 0 3" dir="0 0 -1" directional="false"/>
+    <light pos="0 0 6" dir="0 0 -1" directional="false"/>
     <geom name="floor" pos="0 0 -0.05" size="0 0 .125" type="plane" material="groundplane" conaffinity="15" condim="3"/>
   </worldbody>
 

--- a/hydrax/tasks/double_cart_pole.py
+++ b/hydrax/tasks/double_cart_pole.py
@@ -11,7 +11,7 @@ class DoubleCartPole(Task):
     """A swing-up task for a double pendulum on a cart."""
 
     def __init__(
-        self, planning_horizon: int = 10, sim_steps_per_control_step: int = 10
+        self, planning_horizon: int = 10, sim_steps_per_control_step: int = 8
     ):
         """Load the MuJoCo model and set task parameters."""
         mj_model = mujoco.MjModel.from_xml_path(
@@ -45,5 +45,5 @@ class DoubleCartPole(Task):
         """The terminal cost ϕ(x_T)."""
         upright_cost = 10 * self._distance_to_upright(state)
         centering_cost = 10 * jnp.square(state.qpos[0])
-        velocity_cost = 0.1 * jnp.sum(jnp.square(state.qvel))
+        velocity_cost = jnp.sum(jnp.square(state.qvel))
         return upright_cost + centering_cost + velocity_cost

--- a/hydrax/tasks/double_cart_pole.py
+++ b/hydrax/tasks/double_cart_pole.py
@@ -30,24 +30,20 @@ class DoubleCartPole(Task):
     def _distance_to_upright(self, state: mjx.Data) -> jax.Array:
         """Get a measure of distance to the upright position."""
         tip_z = state.site_xpos[self.tip_id, 2]
-        return jnp.square(tip_z - 4.0)
-
-    def _distance_to_centered(self, state: mjx.Data) -> jax.Array:
-        """Distance to center is measured at the tip, not the cart."""
         tip_x = state.site_xpos[self.tip_id, 0]
-        return jnp.square(tip_x)
+        cart_x = state.qpos[0]
+        return jnp.square(tip_z - 4.0) + jnp.square(tip_x - cart_x)
 
     def running_cost(self, state: mjx.Data, control: jax.Array) -> jax.Array:
         """The running cost ℓ(xₜ, uₜ)."""
-        theta_cost = self._distance_to_upright(state)
-        centering_cost = self._distance_to_centered(state)
+        upright_cost = self._distance_to_upright(state)
         velocity_cost = 0.1 * jnp.sum(jnp.square(state.qvel[1:]))
-        control_cost = 0.01 * jnp.sum(jnp.square(control))
-        return theta_cost + centering_cost + velocity_cost + control_cost
+        control_cost = 0.001 * jnp.sum(jnp.square(control))
+        return upright_cost + velocity_cost + control_cost
 
     def terminal_cost(self, state: mjx.Data) -> jax.Array:
         """The terminal cost ϕ(x_T)."""
-        theta_cost = 10 * self._distance_to_upright(state)
-        centering_cost = 10 * self._distance_to_centered(state)
-        velocity_cost = 0.1 * jnp.sum(jnp.square(state.qvel[1:]))
-        return theta_cost + centering_cost + velocity_cost
+        upright_cost = 10 * self._distance_to_upright(state)
+        centering_cost = 10 * jnp.square(state.qpos[0])
+        velocity_cost = 0.1 * jnp.sum(jnp.square(state.qvel))
+        return upright_cost + centering_cost + velocity_cost


### PR DESCRIPTION
Some improved (but still not perfect) parameters for double-cart-pole swingup.

- Cost prioritizes balancing over the cart, then centering
- Slightly shorter planning horizon
- Model improvements: fix lighting, set default configuration as the "down" position