### PR TITLE
Add manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+# Include all model files in a pip install
+include *.xml
+recursive-include hydrax *

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,5 +79,5 @@ testpaths = [
     "tests",
 ]
 
-[tool.setuptools.package-dir]
-hydrax = "hydrax"
+[tool.setuptools]
+packages = ["hydrax"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,5 +79,5 @@ testpaths = [
     "tests",
 ]
 
-[tool.setuptools]
-packages = ["hydrax"]
+[tool.setuptools.package-dir]
+hydrax = "hydrax"


### PR DESCRIPTION
This allows us to install without the `-e` flag, and with `pip install hydrax@git+https://github.com/vincekurtz/hydrax`.

Particularly useful for installing from another project, so we don't force users to clone multiple repos. 