### PR TITLE
Disable G1 mocap test due to missing target dataset

### DIFF
--- a/tests/test_g1.py
+++ b/tests/test_g1.py
@@ -4,6 +4,7 @@ from typing import Tuple
 import jax
 import jax.numpy as jnp
 import mujoco
+import pytest
 from mujoco import mjx
 
 from hydrax import ROOT
@@ -74,6 +75,7 @@ def test_standup() -> None:
     assert phi > 0.0
 
 
+@pytest.mark.skip(reason="mocap dataset taken off huggingface")
 def test_mocap() -> None:
     """Test the humanoid mocap task."""
     task = HumanoidMocap()


### PR DESCRIPTION
Unitree's motion capture dataset, which used to be available on huggingface [here](https://huggingface.co/unitreerobotics/LAFAN1_Retargeting_Dataset), appears to have been taken down. This results in test failures for the G1 mocap task if the dataset wasn't already cached (#37).

This is a temporary patch that just skips the offending test. Longer term, we should find a better source for mocap references.