### PR TITLE
Loosen deps + introduce `dev` dependency group

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.7.1
+    rev: v0.11.5
     hooks:
     -   id: ruff
         types_or: [ python, pyi, jupyter ]

--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ conda activate hydrax
 Install the package and dependencies:
 
 ```bash
+# option 1: required deps only
 pip install -e .
+
+# option 2: all deps (including dev)
+pip install -e .[dev]
 ```
 
 (Optional) set up pre-commit hooks:

--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ pip install -e .
 pip install -e .[dev]
 ```
 
-(Optional) set up pre-commit hooks:
+(Optional) Set up pre-commit hooks if using development dependencies:
 
 ```bash
 pre-commit autoupdate
 pre-commit install
 ```
 
-(Optional) run unit tests:
+(Optional) Run unit tests if using development dependencies:
 
 ```bash
 pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,16 +14,20 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dependencies = [
-    "jax[cuda12]==0.4.35",
-    "flax==0.10.0",
-    "pytest==8.3.3",
-    "ruff==0.7.1",
-    "pre-commit==4.0.1",
-    "matplotlib==3.9.2",
-    "mujoco==3.2.4",
-    "mujoco-mjx==3.2.4",
-    "evosax==0.1.6",
-    "huggingface_hub==0.29.3",
+    "evosax>=0.1.6",
+    "flax>=0.10.0",
+    "huggingface_hub>=0.29.3",
+    "jax[cuda12]>=0.4.35",
+    "mujoco>=3.2.4",
+    "mujoco-mjx>=3.2.4",
+]
+
+[project.optional-dependencies]
+dev = [
+    "matplotlib>=3.9.2",
+    "pre-commit>=4.0.1",
+    "pytest>=8.3.3",
+    "ruff>=0.7.1",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,9 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python",
 ]
+# TODO: evosax v0.2.0 introduced many breaking changes in the API that cause test failures
 dependencies = [
-    "evosax>=0.1.6",
+    "evosax<0.2.0",
     "flax>=0.10.0",
     "huggingface_hub>=0.29.3",
     "jax[cuda12]>=0.4.35",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ ignore = [
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
-known-first-party = ["hydra"]
+known-first-party = ["hydrax"]
 split-on-trailing-comma = false
 
 [tool.ruff.format]


### PR DESCRIPTION
This PR makes the following changes:
* Updates the `ruff` pre-commit hook version
* Introduces version floors rather than pinning all dependencies so `hydrax` can be used as a dependency in other projects
* Allow slim installation and a dev installation by separating dependencies into two groups
* Fixes a typo naming `hydra` instead of `hydrax` as a known first party dependency
* Updates the README to indicate the option to install with different sets of dependencies

### Notes
* When loosening versions, I discovered that `evosax` recently upgraded to v0.2.0, which introduced a large number of breaking changes to their API. As a result, I applied a hard ceiling on `evosax` that can be lifted once the new API is integrated into `hydrax` in a future PR.