### PR TITLE
Spline Support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
 -   repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.7.1
+    rev: v0.11.5
     hooks:
     -   id: ruff
         types_or: [ python, pyi, jupyter ]

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ distribution that the controls $U = [u_0, u_1, ...]$ are sampled from.
 
 To implement a new planning algorithm, you'll need to inherit from
 [`hydrax.alg_base.SamplingBasedController`](hydrax/alg_base.py) and implement
-the four methods shown below:
+the three methods shown below:
 
 ```python
 class MyControlAlgorithm(SamplingBasedController):
@@ -156,14 +156,9 @@ class MyControlAlgorithm(SamplingBasedController):
         # (costs, controls, observations, etc) stored in the rollouts.
         ...
         return new_params
-
-    def get_action(self, params: Any, t: float) -> Any:
-        # Return the control action applied t seconds into the trajectory.
-        ...
-        return u
 ```
 
-These four methods define a unique sampling-based MPC algorithm. Hydrax takes
+These three methods define a unique sampling-based MPC algorithm. Hydrax takes
 care of the rest, including parallelizing rollouts on GPU and collecting the
 rollout data in a [`Trajectory`](hydrax/alg_base.py) object.
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Available methods:
 
 ## News
 
-- April 11, 2024. Large changes to the core `hydrax` functionality + some breaking changes.
+- April 12, 2024. Large changes to the core `hydrax` functionality + some breaking changes.
     - Splines (and their knots) are now the default parameterization of the control signals and decision variables! Before, it was always assumed that every control step applied a zero-order hold. This is now a special case of the new spline parameterization.
-    - All "time-based" variables are now specified in the controller. Previously, variables like the planning horizon and number of sim steps per control step were specified in the task. Now, the main variables to specify are `T`, the length of the planning horizon in seconds, and `dt`, the control time step. Based on the timestep specified in the model XML, the planning horizon in number of steps as well as the number of sim steps per control step can be inferred, and none of these variables are stored in the task. **This is a breaking change!**
+    - All "time-based" variables are now specified in the controller. Previously, variables like the planning horizon and number of sim steps per control step were specified in the task. Now, the main variables to specify are `T`, the length of the planning horizon in seconds, and `dt`, the control time step (in the model XML). Based on these, the number of planning steps (i.e., the times at which the spline is interpolated) can be inferred, and none of these variables are stored in the task. **This is a breaking change!**
 
 ## Setup (conda)
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Available methods:
 
 ## News
 
-- April 12, 2024. Large changes to the core `hydrax` functionality + some breaking changes.
+- April 13, 2024. Large changes to the core `hydrax` functionality + some breaking changes.
     - Splines (and their knots) are now the default parameterization of the control signals and decision variables! Before, it was always assumed that every control step applied a zero-order hold. This is now a special case of the new spline parameterization.
-    - All "time-based" variables are now specified in the controller. Previously, variables like the planning horizon and number of sim steps per control step were specified in the task. Now, the main variables to specify are `T`, the length of the planning horizon in seconds, and `dt`, the control time step (in the model XML). Based on these, the number of planning steps (i.e., the times at which the spline is interpolated) can be inferred, and none of these variables are stored in the task. **This is a breaking change!**
+    - All "time-based" variables are now specified in the controller. Previously, variables like the planning horizon and number of sim steps per control step were specified in the task. Now, the main variables to specify are `plan_horizon`, the length of the planning horizon in seconds, and `dt`, the control time step (in the model XML). Based on these, the number of planning steps (i.e., the times at which the spline is interpolated) can be inferred, and none of these variables are stored in the task. **This is a breaking change!**
 
 ## Setup (conda)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Available methods:
 
 - April 13, 2024. Large changes to the core `hydrax` functionality + some breaking changes.
     - Splines (and their knots) are now the default parameterization of the control signals and decision variables! Before, it was always assumed that every control step applied a zero-order hold. This is now a special case of the new spline parameterization.
-    - All "time-based" variables are now specified in the controller. Previously, variables like the planning horizon and number of sim steps per control step were specified in the task. Now, the main variables to specify are `plan_horizon`, the length of the planning horizon in seconds, and `dt`, the control time step (in the model XML). Based on these, the number of planning steps (i.e., the times at which the spline is interpolated) can be inferred, and none of these variables are stored in the task. **This is a breaking change!**
+    - All "time-based" variables are now specified in the controller. Previously, variables like the planning horizon and number of sim steps per control step were specified in the task. Now, the main variables to specify are `plan_horizon` (the length of the planning horizon in seconds), `num_knots` (the number of spline knots to plan with), and `dt` (the planning time step (in the model XML)). **This is a breaking change!**
 
 ## Setup (conda)
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ conda activate hydrax
 Install the package and dependencies:
 
 ```bash
+# option 1: required deps only
 pip install -e .
+
+# option 2: all deps (including dev)
+pip install -e .[dev]
 ```
 
 (Optional) set up pre-commit hooks:

--- a/README.md
+++ b/README.md
@@ -49,14 +49,14 @@ pip install -e .
 pip install -e .[dev]
 ```
 
-(Optional) set up pre-commit hooks:
+(Optional) Set up pre-commit hooks if using development dependencies:
 
 ```bash
 pre-commit autoupdate
 pre-commit install
 ```
 
-(Optional) run unit tests:
+(Optional) Run unit tests if using development dependencies:
 
 ```bash
 pytest

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Available methods:
 | [Cross Entropy Method](https://en.wikipedia.org/wiki/Cross-entropy_method) | Fit a Gaussian distribution to the `n` best "elite" rollouts. | [`hydrax.algs.CEM`](hydrax/algs/cem.py) |
 | [Evosax](https://github.com/RobertTLange/evosax/) | Any of the 30+ evolution strategies implemented in `evosax`. Includes CMA-ES, differential evolution, and many more. | [`hydrax.algs.Evosax`](hydrax/algs.evosax.py) |
 
+## News
+
+- April 11, 2024. Large changes to the core `hydrax` functionality + some breaking changes.
+    - Splines (and their knots) are now the default parameterization of the control signals and decision variables! Before, it was always assumed that every control step applied a zero-order hold. This is now a special case of the new spline parameterization.
+    - All "time-based" variables are now specified in the controller. Previously, variables like the planning horizon and number of sim steps per control step were specified in the task. Now, the main variables to specify are `T`, the length of the planning horizon in seconds, and `dt`, the control time step. Based on the timestep specified in the model XML, the planning horizon in number of steps as well as the number of sim steps per control step can be inferred, and none of these variables are stored in the task. **This is a breaking change!**
+
 ## Setup (conda)
 
 Set up a conda env with cuda support (first time only):

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ class MyControlAlgorithm(SamplingBasedController):
         ...
         return params
 
-    def sample_controls(self, params: Any) -> Tuple[jax.Array, Any]:
-        # Sample control sequences U from the policy. Return the samples
+    def sample_knots(self, params: Any) -> Tuple[jax.Array, Any]:
+        # Sample the spline knots U from the policy. Return the samples
         # and the (updated) parameters.
         ...
         return controls, params
@@ -171,7 +171,7 @@ rollout data in a [`Trajectory`](hydrax/alg_base.py) object.
 **Note**: because of
 [the way JAX handles randomness](https://jax.readthedocs.io/en/latest/random-numbers.html),
 we assume the PRNG key is stored as one of the parameters $\theta$. This is why
-`sample_controls` returns updated parameters along with the control samples
+`sample_knots` returns updated parameters along with the control samples
 $U^{(1:N)}$.
 
 For some examples, take a look at [`hydrax.algs`](hydrax/algs).

--- a/examples/cart_pole.py
+++ b/examples/cart_pole.py
@@ -16,7 +16,9 @@ ctrl = PredictiveSampling(
     task,
     num_samples=128,
     noise_level=0.3,
-    spline_type="zero",
+    spline_type="cubic",
+    T=1.0,
+    dt=0.1,
     num_knots=11,
 )
 

--- a/examples/cart_pole.py
+++ b/examples/cart_pole.py
@@ -12,7 +12,13 @@ Run an interactive simulation of a cart-pole swingup
 task = CartPole()
 
 # Set up the controller
-ctrl = PredictiveSampling(task, num_samples=128, noise_level=0.3)
+ctrl = PredictiveSampling(
+    task,
+    num_samples=128,
+    noise_level=0.3,
+    spline_type="zero",
+    num_knots=11,
+)
 
 # Define the model used for simulation
 mj_model = task.mj_model

--- a/examples/cart_pole.py
+++ b/examples/cart_pole.py
@@ -33,8 +33,7 @@ if args.algorithm == "ps" or args.algorithm is None:
         num_samples=128,
         noise_level=0.3,
         spline_type="cubic",
-        T=1.0,
-        dt=0.1,
+        plan_horizon=1.0,
         num_knots=4,
     )
 elif args.algorithm == "mppi":
@@ -45,8 +44,7 @@ elif args.algorithm == "mppi":
         noise_level=0.3,
         temperature=0.1,
         spline_type="cubic",
-        T=1.0,
-        dt=0.1,
+        plan_horizon=1.0,
         num_knots=4,
     )
 elif args.algorithm == "cem":
@@ -58,8 +56,7 @@ elif args.algorithm == "cem":
         sigma_start=0.5,
         sigma_min=0.1,
         spline_type="cubic",
-        T=1.0,
-        dt=0.1,
+        plan_horizon=1.0,
         num_knots=4,
     )
 else:
@@ -74,7 +71,7 @@ run_interactive(
     ctrl,
     mj_model,
     mj_data,
-    frequency=50,
+    frequency=10,
     fixed_camera_id=0,
     show_traces=True,
     max_traces=1,

--- a/examples/cart_pole.py
+++ b/examples/cart_pole.py
@@ -1,6 +1,8 @@
+import argparse
+
 import mujoco
 
-from hydrax.algs import PredictiveSampling
+from hydrax.algs import CEM, MPPI, PredictiveSampling
 from hydrax.simulation.deterministic import run_interactive
 from hydrax.tasks.cart_pole import CartPole
 
@@ -11,16 +13,57 @@ Run an interactive simulation of a cart-pole swingup
 # Define the task (cost and dynamics)
 task = CartPole()
 
-# Set up the controller
-ctrl = PredictiveSampling(
-    task,
-    num_samples=128,
-    noise_level=0.3,
-    spline_type="cubic",
-    T=1.0,
-    dt=0.1,
-    num_knots=11,
+# Parse command-line arguments
+parser = argparse.ArgumentParser(
+    description="Run an interactive simulation of the cube rotation task."
 )
+subparsers = parser.add_subparsers(
+    dest="algorithm", help="Sampling algorithm (choose one)"
+)
+subparsers.add_parser("ps", help="Predictive Sampling")
+subparsers.add_parser("mppi", help="Model Predictive Path Integral Control")
+subparsers.add_parser("cem", help="Cross-Entropy Method")
+args = parser.parse_args()
+
+# Set up the controller
+if args.algorithm == "ps" or args.algorithm is None:
+    print("Running predictive sampling")
+    ctrl = PredictiveSampling(
+        task,
+        num_samples=128,
+        noise_level=0.3,
+        spline_type="cubic",
+        T=1.0,
+        dt=0.1,
+        num_knots=4,
+    )
+elif args.algorithm == "mppi":
+    print("Running MPPI")
+    ctrl = MPPI(
+        task,
+        num_samples=128,
+        noise_level=0.3,
+        temperature=0.1,
+        spline_type="cubic",
+        T=1.0,
+        dt=0.1,
+        num_knots=4,
+    )
+elif args.algorithm == "cem":
+    print("Running CEM")
+    ctrl = CEM(
+        task,
+        num_samples=128,
+        num_elites=3,
+        sigma_start=0.5,
+        sigma_min=0.1,
+        spline_type="cubic",
+        T=1.0,
+        dt=0.1,
+        num_knots=4,
+    )
+else:
+    print("Other algorithms not implemented for this example!")
 
 # Define the model used for simulation
 mj_model = task.mj_model

--- a/examples/cart_pole.py
+++ b/examples/cart_pole.py
@@ -60,7 +60,7 @@ elif args.algorithm == "cem":
         num_knots=4,
     )
 else:
-    print("Other algorithms not implemented for this example!")
+    parser.error("Other algorithms not implemented for this example!")
 
 # Define the model used for simulation
 mj_model = task.mj_model
@@ -71,8 +71,8 @@ run_interactive(
     ctrl,
     mj_model,
     mj_data,
-    frequency=10,
+    frequency=50,
     fixed_camera_id=0,
-    show_traces=True,
+    show_traces=False,
     max_traces=1,
 )

--- a/examples/crane.py
+++ b/examples/crane.py
@@ -19,6 +19,10 @@ ctrl = PredictiveSampling(
     noise_level=0.05,
     num_randomizations=32,
     risk_strategy=ConditionalValueAtRisk(0.1),
+    T=0.8,
+    dt=0.4,
+    spline_type="zero",
+    num_knots=2,
 )
 
 # Define the model used for simulation
@@ -30,7 +34,6 @@ mj_model.dof_damping *= 0.1
 body_idx = mj_model.body("payload").id
 mj_model.body_mass[body_idx] *= 1.5
 mj_model.body_inertia[body_idx] *= 1.5
-mj_model.opt.timestep = 0.002
 
 # Run the interactive simulation
 run_interactive(

--- a/examples/crane.py
+++ b/examples/crane.py
@@ -19,8 +19,7 @@ ctrl = PredictiveSampling(
     noise_level=0.05,
     num_randomizations=32,
     risk_strategy=ConditionalValueAtRisk(0.1),
-    T=0.8,
-    dt=0.4,
+    plan_horizon=0.8,
     spline_type="zero",
     num_knots=3,
 )

--- a/examples/crane.py
+++ b/examples/crane.py
@@ -39,6 +39,6 @@ run_interactive(
     ctrl,
     mj_model,
     mj_data,
-    frequency=10,
-    show_traces=True,
+    frequency=30,
+    show_traces=False,
 )

--- a/examples/crane.py
+++ b/examples/crane.py
@@ -39,6 +39,6 @@ run_interactive(
     ctrl,
     mj_model,
     mj_data,
-    frequency=30,
+    frequency=10,
     show_traces=True,
 )

--- a/examples/crane.py
+++ b/examples/crane.py
@@ -22,7 +22,7 @@ ctrl = PredictiveSampling(
     T=0.8,
     dt=0.4,
     spline_type="zero",
-    num_knots=2,
+    num_knots=3,
 )
 
 # Define the model used for simulation

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -91,9 +91,9 @@ run_interactive(
     ctrl,
     mj_model,
     mj_data,
-    frequency=20,
+    frequency=25,
     fixed_camera_id=None,
-    show_traces=True,
+    show_traces=False,
     max_traces=1,
     trace_color=[1.0, 1.0, 1.0, 1.0],
 )

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -34,7 +34,14 @@ args = parser.parse_args()
 if args.algorithm == "ps" or args.algorithm is None:
     print("Running predictive sampling")
     ctrl = PredictiveSampling(
-        task, num_samples=32, noise_level=0.2, num_randomizations=32
+        task,
+        num_samples=32,
+        noise_level=0.2,
+        num_randomizations=32,
+        T=0.12,
+        dt=0.04,
+        spline_type="zero",
+        num_knots=4,
     )
 elif args.algorithm == "mppi":
     print("Running MPPI")
@@ -44,6 +51,10 @@ elif args.algorithm == "mppi":
         noise_level=0.2,
         temperature=0.001,
         num_randomizations=8,
+        T=0.12,
+        dt=0.04,
+        spline_type="zero",
+        num_knots=4,
     )
 elif args.algorithm == "cem":
     print("Running CEM")
@@ -54,6 +65,10 @@ elif args.algorithm == "cem":
         sigma_start=0.5,
         sigma_min=0.5,
         num_randomizations=8,
+        T=0.12,
+        dt=0.04,
+        spline_type="zero",
+        num_knots=4,
     )
 elif args.algorithm == "cmaes":
     print("Running CMA-ES")
@@ -63,6 +78,10 @@ elif args.algorithm == "cmaes":
         num_samples=128,
         elite_ratio=0.5,
         num_randomizations=8,
+        T=0.12,
+        dt=0.04,
+        spline_type="zero",
+        num_knots=4,
     )
 else:
     parser.error("Invalid algorithm")

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -38,7 +38,7 @@ if args.algorithm == "ps" or args.algorithm is None:
         num_samples=32,
         noise_level=0.2,
         num_randomizations=32,
-        plan_horizon=0.12,
+        plan_horizon=0.25,
         spline_type="zero",
         num_knots=4,
     )
@@ -50,7 +50,7 @@ elif args.algorithm == "mppi":
         noise_level=0.2,
         temperature=0.001,
         num_randomizations=8,
-        plan_horizon=0.12,
+        plan_horizon=0.25,
         spline_type="zero",
         num_knots=4,
     )
@@ -63,7 +63,7 @@ elif args.algorithm == "cem":
         sigma_start=0.5,
         sigma_min=0.5,
         num_randomizations=8,
-        plan_horizon=0.12,
+        plan_horizon=0.25,
         spline_type="zero",
         num_knots=4,
     )
@@ -75,7 +75,7 @@ elif args.algorithm == "cmaes":
         num_samples=128,
         elite_ratio=0.5,
         num_randomizations=8,
-        plan_horizon=0.12,
+        plan_horizon=0.25,
         spline_type="zero",
         num_knots=4,
     )
@@ -91,7 +91,7 @@ run_interactive(
     ctrl,
     mj_model,
     mj_data,
-    frequency=25,
+    frequency=20,
     fixed_camera_id=None,
     show_traces=True,
     max_traces=1,

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -38,8 +38,7 @@ if args.algorithm == "ps" or args.algorithm is None:
         num_samples=32,
         noise_level=0.2,
         num_randomizations=32,
-        T=0.12,
-        dt=0.04,
+        plan_horizon=0.12,
         spline_type="zero",
         num_knots=4,
     )
@@ -51,8 +50,7 @@ elif args.algorithm == "mppi":
         noise_level=0.2,
         temperature=0.001,
         num_randomizations=8,
-        T=0.12,
-        dt=0.04,
+        plan_horizon=0.12,
         spline_type="zero",
         num_knots=4,
     )
@@ -65,8 +63,7 @@ elif args.algorithm == "cem":
         sigma_start=0.5,
         sigma_min=0.5,
         num_randomizations=8,
-        T=0.12,
-        dt=0.04,
+        plan_horizon=0.12,
         spline_type="zero",
         num_knots=4,
     )
@@ -78,8 +75,7 @@ elif args.algorithm == "cmaes":
         num_samples=128,
         elite_ratio=0.5,
         num_randomizations=8,
-        T=0.12,
-        dt=0.04,
+        plan_horizon=0.12,
         spline_type="zero",
         num_knots=4,
     )

--- a/examples/cube_async.py
+++ b/examples/cube_async.py
@@ -39,5 +39,4 @@ if __name__ == "__main__":
         ctrl,
         mj_model,
         mj_data,
-        show_traces=False,
     )

--- a/examples/cube_async.py
+++ b/examples/cube_async.py
@@ -17,7 +17,14 @@ if __name__ == "__main__":
     # Define the task and controller
     task = CubeRotation()
     ctrl = PredictiveSampling(
-        task, num_samples=32, noise_level=0.2, num_randomizations=32
+        task,
+        num_samples=32,
+        noise_level=0.2,
+        num_randomizations=32,
+        T=0.12,
+        dt=0.04,
+        spline_type="zero",
+        num_knots=4,
     )
 
     # Define the model used for simulation (with more realistic parameters)

--- a/examples/cube_async.py
+++ b/examples/cube_async.py
@@ -21,8 +21,7 @@ if __name__ == "__main__":
         num_samples=32,
         noise_level=0.2,
         num_randomizations=32,
-        T=0.12,
-        dt=0.04,
+        plan_horizon=0.12,
         spline_type="zero",
         num_knots=4,
     )

--- a/examples/cube_async.py
+++ b/examples/cube_async.py
@@ -39,4 +39,5 @@ if __name__ == "__main__":
         ctrl,
         mj_model,
         mj_data,
+        show_traces=False,
     )

--- a/examples/double_cart_pole.py
+++ b/examples/double_cart_pole.py
@@ -17,10 +17,9 @@ ctrl = PredictiveSampling(
     task,
     num_samples=1024,
     noise_level=0.3,
-    T=0.8,
-    dt=0.08,
-    spline_type="zero",
-    num_knots=11,
+    plan_horizon=1.0,
+    spline_type="cubic",
+    num_knots=4,
 )
 
 # Define the model used for simulation
@@ -32,7 +31,7 @@ run_interactive(
     ctrl,
     mj_model,
     mj_data,
-    frequency=50,
+    frequency=20,
     fixed_camera_id=0,
     show_traces=True,
     max_traces=1,

--- a/examples/double_cart_pole.py
+++ b/examples/double_cart_pole.py
@@ -31,8 +31,8 @@ run_interactive(
     ctrl,
     mj_model,
     mj_data,
-    frequency=20,
+    frequency=50,
     fixed_camera_id=0,
-    show_traces=True,
+    show_traces=False,
     max_traces=1,
 )

--- a/examples/double_cart_pole.py
+++ b/examples/double_cart_pole.py
@@ -13,7 +13,15 @@ is actuated, and the goal is to swing up the pendulum and balance it upright.
 task = DoubleCartPole()
 
 # Set up the controller
-ctrl = PredictiveSampling(task, num_samples=1024, noise_level=0.3)
+ctrl = PredictiveSampling(
+    task,
+    num_samples=1024,
+    noise_level=0.3,
+    T=0.8,
+    dt=0.08,
+    spline_type="zero",
+    num_knots=11,
+)
 
 # Define the model used for simulation
 mj_model = task.mj_model

--- a/examples/humanoid_mocap.py
+++ b/examples/humanoid_mocap.py
@@ -37,6 +37,10 @@ ctrl = CEM(
     num_elites=20,
     sigma_start=0.1,
     sigma_min=0.1,
+    T=0.6,
+    dt=0.1,
+    spline_type="zero",
+    num_knots=4,
 )
 
 # Define the model used for simulation

--- a/examples/humanoid_mocap.py
+++ b/examples/humanoid_mocap.py
@@ -37,8 +37,7 @@ ctrl = CEM(
     num_elites=20,
     sigma_start=0.1,
     sigma_min=0.1,
-    T=0.6,
-    dt=0.1,
+    plan_horizon=0.6,
     spline_type="zero",
     num_knots=4,
 )

--- a/examples/humanoid_mocap.py
+++ b/examples/humanoid_mocap.py
@@ -44,6 +44,7 @@ ctrl = CEM(
 
 # Define the model used for simulation
 mj_model = task.mj_model
+mj_model.opt.timestep = 0.01
 mj_model.opt.iterations = 10
 mj_model.opt.ls_iterations = 50
 mj_model.opt.o_solimp = [0.9, 0.95, 0.001, 0.5, 2]

--- a/examples/humanoid_mocap.py
+++ b/examples/humanoid_mocap.py
@@ -41,7 +41,6 @@ ctrl = CEM(
 
 # Define the model used for simulation
 mj_model = task.mj_model
-mj_model.opt.timestep = 0.01
 mj_model.opt.iterations = 10
 mj_model.opt.ls_iterations = 50
 mj_model.opt.o_solimp = [0.9, 0.95, 0.001, 0.5, 2]

--- a/examples/humanoid_standup.py
+++ b/examples/humanoid_standup.py
@@ -73,6 +73,6 @@ if __name__ == "__main__":
             ctrl,
             mj_model,
             mj_data,
-            frequency=50,
+            frequency=20,
             show_traces=False,
         )

--- a/examples/humanoid_standup.py
+++ b/examples/humanoid_standup.py
@@ -43,6 +43,7 @@ if __name__ == "__main__":
 
     # Define the model used for simulation (stiffer contact parameters)
     mj_model = task.mj_model
+    mj_model.opt.timestep = 0.01
     mj_model.opt.o_solimp = [0.9, 0.95, 0.001, 0.5, 2]
     mj_model.opt.enableflags = mujoco.mjtEnableBit.mjENBL_OVERRIDE
 
@@ -73,6 +74,6 @@ if __name__ == "__main__":
             ctrl,
             mj_model,
             mj_data,
-            frequency=20,
+            frequency=50,
             show_traces=False,
         )

--- a/examples/humanoid_standup.py
+++ b/examples/humanoid_standup.py
@@ -36,8 +36,7 @@ if __name__ == "__main__":
         noise_level=0.3,
         temperature=0.1,
         num_randomizations=4,
-        T=0.6,
-        dt=0.1,
+        plan_horizon=0.6,
         spline_type="zero",
         num_knots=4,
     )

--- a/examples/humanoid_standup.py
+++ b/examples/humanoid_standup.py
@@ -36,11 +36,14 @@ if __name__ == "__main__":
         noise_level=0.3,
         temperature=0.1,
         num_randomizations=4,
+        T=0.6,
+        dt=0.1,
+        spline_type="zero",
+        num_knots=4,
     )
 
     # Define the model used for simulation (stiffer contact parameters)
     mj_model = task.mj_model
-    mj_model.opt.timestep = 0.01
     mj_model.opt.o_solimp = [0.9, 0.95, 0.001, 0.5, 2]
     mj_model.opt.enableflags = mujoco.mjtEnableBit.mjENBL_OVERRIDE
 

--- a/examples/particle.py
+++ b/examples/particle.py
@@ -134,6 +134,6 @@ run_interactive(
     mj_model,
     mj_data,
     frequency=50,
-    show_traces=True,
+    show_traces=False,
     max_traces=5,
 )

--- a/examples/particle.py
+++ b/examples/particle.py
@@ -61,19 +61,44 @@ elif args.algorithm == "mppi":
 
 elif args.algorithm == "cmaes":
     print("Running CMA-ES")
-    ctrl = Evosax(task, evosax.Sep_CMA_ES, num_samples=16, elite_ratio=0.5)
+    ctrl = Evosax(
+        task,
+        evosax.Sep_CMA_ES,
+        num_samples=16,
+        elite_ratio=0.5,
+        T=0.25,
+        dt=0.05,
+    )
 
 elif args.algorithm == "samr":
     print("Running genetic algorithm with Self-Adaptation Mutation Rate (SAMR)")
-    ctrl = Evosax(task, evosax.SAMR_GA, num_samples=16)
+    ctrl = Evosax(
+        task,
+        evosax.SAMR_GA,
+        num_samples=16,
+        T=0.25,
+        dt=0.05,
+    )
 
 elif args.algorithm == "de":
     print("Running Differential Evolution (DE)")
-    ctrl = Evosax(task, evosax.DE, num_samples=16)
+    ctrl = Evosax(
+        task,
+        evosax.DE,
+        num_samples=16,
+        T=0.25,
+        dt=0.05,
+    )
 
 elif args.algorithm == "gld":
     print("Running Gradient-Less Descent (GLD)")
-    ctrl = Evosax(task, evosax.GLD, num_samples=16)
+    ctrl = Evosax(
+        task,
+        evosax.GLD,
+        num_samples=16,
+        T=0.25,
+        dt=0.05,
+    )
 
 elif args.algorithm == "rs":
     print("Running uniform random search")
@@ -82,7 +107,12 @@ elif args.algorithm == "rs":
         range_max=1.0,
     )
     ctrl = Evosax(
-        task, evosax.RandomSearch, num_samples=16, es_params=es_params
+        task,
+        evosax.RandomSearch,
+        num_samples=16,
+        es_params=es_params,
+        T=0.25,
+        dt=0.05,
     )
 else:
     parser.error("Invalid algorithm")

--- a/examples/particle.py
+++ b/examples/particle.py
@@ -44,11 +44,20 @@ if args.algorithm == "ps" or args.algorithm is None:
         noise_level=0.1,
         num_randomizations=10,
         risk_strategy=WorstCase(),
+        T=0.25,
+        dt=0.05,
     )
 
 elif args.algorithm == "mppi":
     print("Running MPPI")
-    ctrl = MPPI(task, num_samples=16, noise_level=0.3, temperature=0.01)
+    ctrl = MPPI(
+        task,
+        num_samples=16,
+        noise_level=0.3,
+        temperature=0.01,
+        T=0.25,
+        dt=0.05,
+    )
 
 elif args.algorithm == "cmaes":
     print("Running CMA-ES")

--- a/examples/particle.py
+++ b/examples/particle.py
@@ -44,8 +44,7 @@ if args.algorithm == "ps" or args.algorithm is None:
         noise_level=0.1,
         num_randomizations=10,
         risk_strategy=WorstCase(),
-        T=0.25,
-        dt=0.05,
+        plan_horizon=0.25,
         spline_type="zero",
         num_knots=11,
     )
@@ -57,8 +56,7 @@ elif args.algorithm == "mppi":
         num_samples=16,
         noise_level=0.3,
         temperature=0.01,
-        T=0.25,
-        dt=0.05,
+        plan_horizon=0.25,
         spline_type="zero",
         num_knots=11,
     )
@@ -70,8 +68,7 @@ elif args.algorithm == "cmaes":
         evosax.Sep_CMA_ES,
         num_samples=16,
         elite_ratio=0.5,
-        T=0.25,
-        dt=0.05,
+        plan_horizon=0.25,
         spline_type="zero",
         num_knots=11,
     )
@@ -82,8 +79,7 @@ elif args.algorithm == "samr":
         task,
         evosax.SAMR_GA,
         num_samples=16,
-        T=0.25,
-        dt=0.05,
+        plan_horizon=0.25,
         spline_type="zero",
         num_knots=11,
     )
@@ -94,8 +90,7 @@ elif args.algorithm == "de":
         task,
         evosax.DE,
         num_samples=16,
-        T=0.25,
-        dt=0.05,
+        plan_horizon=0.25,
         spline_type="zero",
         num_knots=11,
     )
@@ -106,8 +101,7 @@ elif args.algorithm == "gld":
         task,
         evosax.GLD,
         num_samples=16,
-        T=0.25,
-        dt=0.05,
+        plan_horizon=0.25,
         spline_type="zero",
         num_knots=11,
     )
@@ -123,8 +117,7 @@ elif args.algorithm == "rs":
         evosax.RandomSearch,
         num_samples=16,
         es_params=es_params,
-        T=0.25,
-        dt=0.05,
+        plan_horizon=0.25,
         spline_type="zero",
         num_knots=11,
     )

--- a/examples/particle.py
+++ b/examples/particle.py
@@ -46,6 +46,8 @@ if args.algorithm == "ps" or args.algorithm is None:
         risk_strategy=WorstCase(),
         T=0.25,
         dt=0.05,
+        spline_type="zero",
+        num_knots=11,
     )
 
 elif args.algorithm == "mppi":
@@ -57,6 +59,8 @@ elif args.algorithm == "mppi":
         temperature=0.01,
         T=0.25,
         dt=0.05,
+        spline_type="zero",
+        num_knots=11,
     )
 
 elif args.algorithm == "cmaes":
@@ -68,6 +72,8 @@ elif args.algorithm == "cmaes":
         elite_ratio=0.5,
         T=0.25,
         dt=0.05,
+        spline_type="zero",
+        num_knots=11,
     )
 
 elif args.algorithm == "samr":
@@ -78,6 +84,8 @@ elif args.algorithm == "samr":
         num_samples=16,
         T=0.25,
         dt=0.05,
+        spline_type="zero",
+        num_knots=11,
     )
 
 elif args.algorithm == "de":
@@ -88,6 +96,8 @@ elif args.algorithm == "de":
         num_samples=16,
         T=0.25,
         dt=0.05,
+        spline_type="zero",
+        num_knots=11,
     )
 
 elif args.algorithm == "gld":
@@ -98,6 +108,8 @@ elif args.algorithm == "gld":
         num_samples=16,
         T=0.25,
         dt=0.05,
+        spline_type="zero",
+        num_knots=11,
     )
 
 elif args.algorithm == "rs":
@@ -113,6 +125,8 @@ elif args.algorithm == "rs":
         es_params=es_params,
         T=0.25,
         dt=0.05,
+        spline_type="zero",
+        num_knots=11,
     )
 else:
     parser.error("Invalid algorithm")

--- a/examples/pendulum.py
+++ b/examples/pendulum.py
@@ -63,7 +63,7 @@ run_interactive(
     ctrl,
     mj_model,
     mj_data,
-    frequency=50,
+    frequency=20,
     fixed_camera_id=0,
     show_traces=True,
     max_traces=1,

--- a/examples/pendulum.py
+++ b/examples/pendulum.py
@@ -12,7 +12,7 @@ Run an interactive simulation of the pendulum swingup task.
 """
 
 # Define the task (cost and dynamics)
-task = Pendulum(planning_horizon=10, sim_steps_per_control_step=5)
+task = Pendulum()
 
 # Parse command-line arguments
 parser = argparse.ArgumentParser(
@@ -28,10 +28,27 @@ args = parser.parse_args()
 # Set the controller based on command-line arguments
 if args.algorithm == "ps" or args.algorithm is None:
     print("Running predictive sampling")
-    ctrl = PredictiveSampling(task, num_samples=32, noise_level=0.1)
+    ctrl = PredictiveSampling(
+        task,
+        num_samples=32,
+        noise_level=0.1,
+        T=1.0,
+        dt=0.1,
+        spline_type="zero",
+        num_knots=11,
+    )
 elif args.algorithm == "mppi":
     print("Running MPPI")
-    ctrl = MPPI(task, num_samples=32, noise_level=0.1, temperature=0.1)
+    ctrl = MPPI(
+        task,
+        num_samples=32,
+        noise_level=0.2,
+        temperature=0.1,
+        T=1.0,
+        dt=0.1,
+        spline_type="zero",
+        num_knots=11,
+    )
 else:
     parser.error("Invalid algorithm")
 

--- a/examples/pendulum.py
+++ b/examples/pendulum.py
@@ -32,8 +32,7 @@ if args.algorithm == "ps" or args.algorithm is None:
         task,
         num_samples=32,
         noise_level=0.1,
-        T=1.0,
-        dt=0.1,
+        plan_horizon=1.0,
         spline_type="zero",
         num_knots=11,
     )
@@ -44,8 +43,7 @@ elif args.algorithm == "mppi":
         num_samples=32,
         noise_level=0.2,
         temperature=0.1,
-        T=1.0,
-        dt=0.1,
+        plan_horizon=1.0,
         spline_type="zero",
         num_knots=11,
     )

--- a/examples/pendulum.py
+++ b/examples/pendulum.py
@@ -63,8 +63,8 @@ run_interactive(
     ctrl,
     mj_model,
     mj_data,
-    frequency=20,
+    frequency=50,
     fixed_camera_id=0,
-    show_traces=True,
+    show_traces=False,
     max_traces=1,
 )

--- a/examples/pusht.py
+++ b/examples/pusht.py
@@ -37,6 +37,6 @@ run_interactive(
     ctrl,
     mj_model,
     mj_data,
-    frequency=50,
+    frequency=20,
     show_traces=True,
 )

--- a/examples/pusht.py
+++ b/examples/pusht.py
@@ -13,12 +13,18 @@ task = PushT()
 
 # Set up the controller
 ctrl = PredictiveSampling(
-    task, num_samples=128, noise_level=0.4, num_randomizations=4
+    task,
+    num_samples=128,
+    noise_level=0.4,
+    num_randomizations=4,
+    T=0.5,
+    dt=0.05,
+    spline_type="zero",
+    num_knots=6,
 )
 
 # Define the model used for simulation
 mj_model = task.mj_model
-mj_model.opt.timestep = 0.001
 mj_model.opt.iterations = 100
 mj_model.opt.ls_iterations = 50
 mj_data = mujoco.MjData(mj_model)

--- a/examples/pusht.py
+++ b/examples/pusht.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 import mujoco
 
 from hydrax.algs import PredictiveSampling
@@ -25,7 +23,7 @@ ctrl = PredictiveSampling(
 )
 
 # Define the model used for simulation
-mj_model = deepcopy(task.mj_model)
+mj_model = task.mj_model
 mj_model.opt.timestep = 0.001
 mj_model.opt.iterations = 100
 mj_model.opt.ls_iterations = 50
@@ -37,6 +35,6 @@ run_interactive(
     ctrl,
     mj_model,
     mj_data,
-    frequency=20,
-    show_traces=True,
+    frequency=50,
+    show_traces=False,
 )

--- a/examples/pusht.py
+++ b/examples/pusht.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 import mujoco
 
 from hydrax.algs import PredictiveSampling
@@ -17,14 +19,14 @@ ctrl = PredictiveSampling(
     num_samples=128,
     noise_level=0.4,
     num_randomizations=4,
-    T=0.5,
-    dt=0.05,
+    plan_horizon=0.5,
     spline_type="zero",
     num_knots=6,
 )
 
 # Define the model used for simulation
-mj_model = task.mj_model
+mj_model = deepcopy(task.mj_model)
+mj_model.opt.timestep = 0.001
 mj_model.opt.iterations = 100
 mj_model.opt.ls_iterations = 50
 mj_data = mujoco.MjData(mj_model)

--- a/examples/walker.py
+++ b/examples/walker.py
@@ -42,6 +42,7 @@ elif args.algorithm == "mppi":
         num_samples=128,
         noise_level=0.5,
         temperature=0.1,
+        plan_horizon=0.6,
         spline_type="zero",
         num_knots=5,
     )
@@ -59,7 +60,7 @@ run_interactive(
     ctrl,
     mj_model,
     mj_data,
-    frequency=50,
+    frequency=20,
     fixed_camera_id=0,
     show_traces=True,
     max_traces=1,

--- a/examples/walker.py
+++ b/examples/walker.py
@@ -31,8 +31,7 @@ if args.algorithm == "ps" or args.algorithm is None:
         task,
         num_samples=128,
         noise_level=0.5,
-        T=0.6,
-        dt=0.15,
+        plan_horizon=0.6,
         spline_type="zero",
         num_knots=5,
     )

--- a/examples/walker.py
+++ b/examples/walker.py
@@ -27,10 +27,25 @@ args = parser.parse_args()
 # Set the controller based on command-line arguments
 if args.algorithm == "ps" or args.algorithm is None:
     print("Running predictive sampling")
-    ctrl = PredictiveSampling(task, num_samples=128, noise_level=0.5)
+    ctrl = PredictiveSampling(
+        task,
+        num_samples=128,
+        noise_level=0.5,
+        T=0.6,
+        dt=0.15,
+        spline_type="zero",
+        num_knots=5,
+    )
 elif args.algorithm == "mppi":
     print("Running MPPI")
-    ctrl = MPPI(task, num_samples=128, noise_level=0.5, temperature=0.1)
+    ctrl = MPPI(
+        task,
+        num_samples=128,
+        noise_level=0.5,
+        temperature=0.1,
+        spline_type="zero",
+        num_knots=5,
+    )
 else:
     parser.error("Invalid algorithm")
 

--- a/examples/walker.py
+++ b/examples/walker.py
@@ -60,8 +60,8 @@ run_interactive(
     ctrl,
     mj_model,
     mj_data,
-    frequency=20,
+    frequency=50,
     fixed_camera_id=0,
-    show_traces=True,
+    show_traces=False,
     max_traces=1,
 )

--- a/hydrax/alg_base.py
+++ b/hydrax/alg_base.py
@@ -17,10 +17,10 @@ class Trajectory:
     """Data class for storing rollout data.
 
     Attributes:
-        controls: Control actions for each time step (size H).
-        knots: Control spline knots (size num_knots).
-        costs: Costs associated with each time step (size H+1).
-        trace_sites: Positions of trace sites at each time step (size H+1).
+        controls: Control actions of shape (num_rollouts, H, nu).
+        knots: Control spline knots of shape (num_rollouts, num_knots, nu).
+        costs: Costs of shape (num_rollouts, H+1).
+        trace_sites: Positions of trace sites of shape (num_rollouts, H+1, 3).
     """
 
     controls: jax.Array

--- a/hydrax/alg_base.py
+++ b/hydrax/alg_base.py
@@ -16,6 +16,9 @@ from hydrax.utils.spline import get_interp_func
 class Trajectory:
     """Data class for storing rollout data.
 
+    Throughout, H denotes the number of control steps (given by the times at
+    which the control spline is interpolated).
+
     Attributes:
         controls: Control actions of shape (num_rollouts, H, nu).
         knots: Control spline knots of shape (num_rollouts, num_knots, nu).

--- a/hydrax/alg_base.py
+++ b/hydrax/alg_base.py
@@ -292,7 +292,9 @@ class SamplingBasedController(ABC):
 
         Args:
             params: The policy parameters, U ~ π(params).
-            t: The time from the start of the trajectory of shape (1,).
+            t: The current time at which to query the spline. Spline times are
+                continually evolving as the simulation progresses, so this
+                number should roughly track mj_data.time.
 
         Returns:
             The control action u(t).

--- a/hydrax/algs/cem.py
+++ b/hydrax/algs/cem.py
@@ -77,7 +77,9 @@ class CEM(SamplingBasedController):
         """Initialize the policy parameters."""
         _params = super().init_params(seed)
         cov = jnp.full_like(_params.mean, self.sigma_start)
-        return CEMParams(mean=_params.mean, cov=cov, rng=_params.rng)
+        return CEMParams(
+            tk=_params.tk, mean=_params.mean, cov=cov, rng=_params.rng
+        )
 
     def sample_knots(self, params: CEMParams) -> Tuple[jax.Array, CEMParams]:
         """Sample a control sequence."""

--- a/hydrax/algs/cem.py
+++ b/hydrax/algs/cem.py
@@ -14,9 +14,10 @@ class CEMParams(SamplingParams):
     """Policy parameters for the cross-entropy method.
 
     Attributes:
-        mean: The mean of the control distribution, μ = [u₀, u₁, ..., ].
-        cov: The (diagonal) covariance of the control distribution.
+        tk: The knot times of the control spline.
+        mean: The mean of the control spline knot distribution, μ = [u₀, ...].
         rng: The pseudo-random number generator key.
+        cov: The (diagonal) covariance of the control distribution.
     """
 
     cov: jax.Array

--- a/hydrax/algs/cem.py
+++ b/hydrax/algs/cem.py
@@ -35,8 +35,7 @@ class CEM(SamplingBasedController):
         num_randomizations: int = 1,
         risk_strategy: RiskStrategy = None,
         seed: int = 0,
-        T: float = 1.0,
-        dt: float = 0.01,
+        plan_horizon: float = 1.0,
         spline_type: Literal["zero", "linear", "cubic"] = "zero",
         num_knots: int = 4,
     ) -> None:
@@ -52,8 +51,7 @@ class CEM(SamplingBasedController):
             risk_strategy: How to combining costs from different randomizations.
                            Defaults to average cost.
             seed: The random seed for domain randomization.
-            T: The time horizon for the rollout in seconds.
-            dt: The time step for the controller in seconds.
+            plan_horizon: The time horizon for the rollout in seconds.
             spline_type: The type of spline used for control interpolation.
                          Defaults to "zero" (zero-order hold).
             num_knots: The number of knots in the control spline.
@@ -63,8 +61,7 @@ class CEM(SamplingBasedController):
             num_randomizations=num_randomizations,
             risk_strategy=risk_strategy,
             seed=seed,
-            T=T,
-            dt=dt,
+            plan_horizon=plan_horizon,
             spline_type=spline_type,
             num_knots=num_knots,
         )

--- a/hydrax/algs/evosax.py
+++ b/hydrax/algs/evosax.py
@@ -45,8 +45,10 @@ class Evosax(SamplingBasedController):
         num_randomizations: int = 1,
         risk_strategy: RiskStrategy = None,
         seed: int = 0,
+        T: float = 1.0,
+        dt: float = 0.01,
         **kwargs,
-    ):
+    ) -> None:
         """Initialize the controller.
 
         Args:
@@ -58,9 +60,18 @@ class Evosax(SamplingBasedController):
             risk_strategy: How to combining costs from different randomizations.
                            Defaults to average cost.
             seed: The random seed for domain randomization.
+            T: The time horizon for the rollout in seconds.
+            dt: The time step for the controller in seconds.
             **kwargs: Additional keyword arguments for the optimizer.
         """
-        super().__init__(task, num_randomizations, risk_strategy, seed)
+        super().__init__(
+            task,
+            num_randomizations=num_randomizations,
+            risk_strategy=risk_strategy,
+            seed=seed,
+            T=T,
+            dt=dt,
+        )
 
         self.strategy = optimizer(
             popsize=num_samples,
@@ -80,7 +91,7 @@ class Evosax(SamplingBasedController):
         opt_state = self.strategy.initialize(init_rng, self.es_params)
         return EvosaxParams(controls=controls, opt_state=opt_state, rng=rng)
 
-    def sample_controls(
+    def sample_knots(
         self, params: EvosaxParams
     ) -> Tuple[jax.Array, EvosaxParams]:
         """Sample control sequences from the proposal distribution."""

--- a/hydrax/algs/evosax.py
+++ b/hydrax/algs/evosax.py
@@ -19,9 +19,10 @@ class EvosaxParams(SamplingParams):
     """Policy parameters for evosax optimizers.
 
     Attributes:
+        tk: The knot times of the control spline.
         mean: The mean of the control spline knot distribution, μ = [u₀, ...].
-        opt_state: The state of the evosax optimizer (covariance, etc.).
         rng: The pseudo-random number generator key.
+        opt_state: The state of the evosax optimizer (covariance, etc.).
     """
 
     opt_state: EvoState

--- a/hydrax/algs/evosax.py
+++ b/hydrax/algs/evosax.py
@@ -43,8 +43,7 @@ class Evosax(SamplingBasedController):
         num_randomizations: int = 1,
         risk_strategy: RiskStrategy = None,
         seed: int = 0,
-        T: float = 1.0,
-        dt: float = 0.01,
+        plan_horizon: float = 1.0,
         spline_type: Literal["zero", "linear", "cubic"] = "zero",
         num_knots: int = 4,
         **kwargs,
@@ -60,8 +59,7 @@ class Evosax(SamplingBasedController):
             risk_strategy: How to combining costs from different randomizations.
                            Defaults to average cost.
             seed: The random seed for domain randomization.
-            T: The time horizon for the rollout in seconds.
-            dt: The time step for the controller in seconds.
+            plan_horizon: The time horizon for the rollout in seconds.
             spline_type: The type of spline used for control interpolation.
                          Defaults to "zero" (zero-order hold).
             num_knots: The number of knots in the control spline.
@@ -72,8 +70,7 @@ class Evosax(SamplingBasedController):
             num_randomizations=num_randomizations,
             risk_strategy=risk_strategy,
             seed=seed,
-            T=T,
-            dt=dt,
+            plan_horizon=plan_horizon,
             spline_type=spline_type,
             num_knots=num_knots,
         )

--- a/hydrax/algs/evosax.py
+++ b/hydrax/algs/evosax.py
@@ -93,7 +93,9 @@ class Evosax(SamplingBasedController):
         _params = super().init_params(seed)
         rng, init_rng = jax.random.split(_params.rng)
         opt_state = self.strategy.initialize(init_rng, self.es_params)
-        return EvosaxParams(mean=_params.mean, opt_state=opt_state, rng=rng)
+        return EvosaxParams(
+            tk=_params.tk, mean=_params.mean, opt_state=opt_state, rng=rng
+        )
 
     def sample_knots(
         self, params: EvosaxParams

--- a/hydrax/algs/mppi.py
+++ b/hydrax/algs/mppi.py
@@ -35,8 +35,7 @@ class MPPI(SamplingBasedController):
         num_randomizations: int = 1,
         risk_strategy: RiskStrategy = None,
         seed: int = 0,
-        T: float = 1.0,
-        dt: float = 0.01,
+        plan_horizon: float = 1.0,
         spline_type: Literal["zero", "linear", "cubic"] = "zero",
         num_knots: int = 4,
     ) -> None:
@@ -52,8 +51,7 @@ class MPPI(SamplingBasedController):
             risk_strategy: How to combining costs from different randomizations.
                            Defaults to average cost.
             seed: The random seed for domain randomization.
-            T: The time horizon for the rollout in seconds.
-            dt: The time step for the controller in seconds.
+            plan_horizon: The time horizon for the rollout in seconds.
             spline_type: The type of spline used for control interpolation.
                          Defaults to "zero" (zero-order hold).
             num_knots: The number of knots in the control spline.
@@ -63,8 +61,7 @@ class MPPI(SamplingBasedController):
             num_randomizations=num_randomizations,
             risk_strategy=risk_strategy,
             seed=seed,
-            T=T,
-            dt=dt,
+            plan_horizon=plan_horizon,
             spline_type=spline_type,
             num_knots=num_knots,
         )

--- a/hydrax/algs/mppi.py
+++ b/hydrax/algs/mppi.py
@@ -14,6 +14,11 @@ class MPPIParams(SamplingParams):
     """Policy parameters for model-predictive path integral control.
 
     Same as SamplingParams, but with a different name for clarity.
+
+    Attributes:
+        tk: The knot times of the control spline.
+        mean: The mean of the control spline knot distribution, μ = [u₀, ...].
+        rng: The pseudo-random number generator key.
     """
 
 

--- a/hydrax/algs/mppi.py
+++ b/hydrax/algs/mppi.py
@@ -1,25 +1,20 @@
-from typing import Tuple
+from typing import Literal, Tuple
 
 import jax
 import jax.numpy as jnp
 from flax.struct import dataclass
 
-from hydrax.alg_base import SamplingBasedController, Trajectory
+from hydrax.alg_base import SamplingBasedController, SamplingParams, Trajectory
 from hydrax.risk import RiskStrategy
 from hydrax.task_base import Task
 
 
 @dataclass
-class MPPIParams:
+class MPPIParams(SamplingParams):
     """Policy parameters for model-predictive path integral control.
 
-    Attributes:
-        mean: The mean of the control distribution, μ = [u₀, u₁, ..., ].
-        rng: The pseudo-random number generator key.
+    Same as SamplingParams, but with a different name for clarity.
     """
-
-    mean: jax.Array
-    rng: jax.Array
 
 
 class MPPI(SamplingBasedController):
@@ -40,7 +35,11 @@ class MPPI(SamplingBasedController):
         num_randomizations: int = 1,
         risk_strategy: RiskStrategy = None,
         seed: int = 0,
-    ):
+        T: float = 1.0,
+        dt: float = 0.01,
+        spline_type: Literal["zero", "linear", "cubic"] = "zero",
+        num_knots: int = 4,
+    ) -> None:
         """Initialize the controller.
 
         Args:
@@ -53,28 +52,39 @@ class MPPI(SamplingBasedController):
             risk_strategy: How to combining costs from different randomizations.
                            Defaults to average cost.
             seed: The random seed for domain randomization.
+            T: The time horizon for the rollout in seconds.
+            dt: The time step for the controller in seconds.
+            spline_type: The type of spline used for control interpolation.
+                         Defaults to "zero" (zero-order hold).
+            num_knots: The number of knots in the control spline.
         """
-        super().__init__(task, num_randomizations, risk_strategy, seed)
+        super().__init__(
+            task,
+            num_randomizations=num_randomizations,
+            risk_strategy=risk_strategy,
+            seed=seed,
+            T=T,
+            dt=dt,
+            spline_type=spline_type,
+            num_knots=num_knots,
+        )
         self.noise_level = noise_level
         self.num_samples = num_samples
         self.temperature = temperature
 
     def init_params(self, seed: int = 0) -> MPPIParams:
         """Initialize the policy parameters."""
-        rng = jax.random.key(seed)
-        mean = jnp.zeros((self.task.planning_horizon, self.task.model.nu))
-        return MPPIParams(mean=mean, rng=rng)
+        _params = super().init_params(seed)
+        return MPPIParams(mean=_params.mean, rng=_params.rng)
 
-    def sample_controls(
-        self, params: MPPIParams
-    ) -> Tuple[jax.Array, MPPIParams]:
+    def sample_knots(self, params: MPPIParams) -> Tuple[jax.Array, MPPIParams]:
         """Sample a control sequence."""
         rng, sample_rng = jax.random.split(params.rng)
         noise = jax.random.normal(
             sample_rng,
             (
                 self.num_samples,
-                self.task.planning_horizon,
+                self.num_knots,
                 self.task.model.nu,
             ),
         )
@@ -88,11 +98,5 @@ class MPPI(SamplingBasedController):
         costs = jnp.sum(rollouts.costs, axis=1)  # sum over time steps
         # N.B. jax.nn.softmax takes care of details like baseline subtraction.
         weights = jax.nn.softmax(-costs / self.temperature, axis=0)
-        mean = jnp.sum(weights[:, None, None] * rollouts.controls, axis=0)
+        mean = jnp.sum(weights[:, None, None] * rollouts.knots, axis=0)
         return params.replace(mean=mean)
-
-    def get_action(self, params: MPPIParams, t: float) -> jax.Array:
-        """Get the control action for the current time step, zero order hold."""
-        idx_float = t / self.task.dt  # zero order hold
-        idx = jnp.floor(idx_float).astype(jnp.int32)
-        return params.mean[idx]

--- a/hydrax/algs/mppi.py
+++ b/hydrax/algs/mppi.py
@@ -75,7 +75,7 @@ class MPPI(SamplingBasedController):
     def init_params(self, seed: int = 0) -> MPPIParams:
         """Initialize the policy parameters."""
         _params = super().init_params(seed)
-        return MPPIParams(mean=_params.mean, rng=_params.rng)
+        return MPPIParams(tk=_params.tk, mean=_params.mean, rng=_params.rng)
 
     def sample_knots(self, params: MPPIParams) -> Tuple[jax.Array, MPPIParams]:
         """Sample a control sequence."""

--- a/hydrax/algs/predictive_sampling.py
+++ b/hydrax/algs/predictive_sampling.py
@@ -91,9 +91,3 @@ class PredictiveSampling(SamplingBasedController):
         best_idx = jnp.argmin(costs)
         mean = rollouts.knots[best_idx]
         return params.replace(mean=mean)
-
-    def get_action(self, params: PSParams, t: float) -> jax.Array:
-        """Get the control action for the current time step, zero order hold."""
-        idx_float = t / self.task.dt  # zero order hold
-        idx = jnp.floor(idx_float).astype(jnp.int32)
-        return params.mean[idx]

--- a/hydrax/algs/predictive_sampling.py
+++ b/hydrax/algs/predictive_sampling.py
@@ -28,6 +28,8 @@ class PredictiveSampling(SamplingBasedController):
         num_randomizations: int = 1,
         risk_strategy: RiskStrategy = None,
         seed: int = 0,
+        T: float = 1.0,
+        dt: float = 0.01,
         spline_type: Literal["zero", "linear", "cubic"] = "zero",
         num_knots: int = 4,
     ) -> None:
@@ -41,6 +43,8 @@ class PredictiveSampling(SamplingBasedController):
             risk_strategy: How to combining costs from different randomizations.
                            Defaults to average cost.
             seed: The random seed for domain randomization.
+            T: The time horizon for the rollout in seconds.
+            dt: The time step for the controller in seconds.
             spline_type: The type of spline used for control interpolation.
                          Defaults to "zero" (zero-order hold).
             num_knots: The number of knots in the control spline.
@@ -50,6 +54,8 @@ class PredictiveSampling(SamplingBasedController):
             num_randomizations=num_randomizations,
             risk_strategy=risk_strategy,
             seed=seed,
+            T=T,
+            dt=dt,
             spline_type=spline_type,
             num_knots=num_knots,
         )
@@ -61,7 +67,7 @@ class PredictiveSampling(SamplingBasedController):
         _params = super().init_params(seed)
         return PSParams(mean=_params.mean, rng=_params.rng)
 
-    def sample_controls(self, params: PSParams) -> Tuple[jax.Array, PSParams]:
+    def sample_knots(self, params: PSParams) -> Tuple[jax.Array, PSParams]:
         """Sample a control sequence."""
         rng, sample_rng = jax.random.split(params.rng)
         noise = jax.random.normal(

--- a/hydrax/algs/predictive_sampling.py
+++ b/hydrax/algs/predictive_sampling.py
@@ -28,8 +28,7 @@ class PredictiveSampling(SamplingBasedController):
         num_randomizations: int = 1,
         risk_strategy: RiskStrategy = None,
         seed: int = 0,
-        T: float = 1.0,
-        dt: float = 0.01,
+        plan_horizon: float = 1.0,
         spline_type: Literal["zero", "linear", "cubic"] = "zero",
         num_knots: int = 4,
     ) -> None:
@@ -43,8 +42,7 @@ class PredictiveSampling(SamplingBasedController):
             risk_strategy: How to combining costs from different randomizations.
                            Defaults to average cost.
             seed: The random seed for domain randomization.
-            T: The time horizon for the rollout in seconds.
-            dt: The time step for the controller in seconds.
+            plan_horizon: The time horizon for the rollout in seconds.
             spline_type: The type of spline used for control interpolation.
                          Defaults to "zero" (zero-order hold).
             num_knots: The number of knots in the control spline.
@@ -54,8 +52,7 @@ class PredictiveSampling(SamplingBasedController):
             num_randomizations=num_randomizations,
             risk_strategy=risk_strategy,
             seed=seed,
-            T=T,
-            dt=dt,
+            plan_horizon=plan_horizon,
             spline_type=spline_type,
             num_knots=num_knots,
         )

--- a/hydrax/algs/predictive_sampling.py
+++ b/hydrax/algs/predictive_sampling.py
@@ -14,6 +14,11 @@ class PSParams(SamplingParams):
     """Policy parameters for predictive sampling.
 
     Same as SamplingParams, but with a different name for clarity.
+
+    Attributes:
+        tk: The knot times of the control spline.
+        mean: The mean of the control spline knot distribution, μ = [u₀, ...].
+        rng: The pseudo-random number generator key.
     """
 
 

--- a/hydrax/algs/predictive_sampling.py
+++ b/hydrax/algs/predictive_sampling.py
@@ -65,7 +65,7 @@ class PredictiveSampling(SamplingBasedController):
     def init_params(self, seed: int = 0) -> PSParams:
         """Initialize the policy parameters."""
         _params = super().init_params(seed)
-        return PSParams(mean=_params.mean, rng=_params.rng)
+        return PSParams(tk=_params.tk, mean=_params.mean, rng=_params.rng)
 
     def sample_knots(self, params: PSParams) -> Tuple[jax.Array, PSParams]:
         """Sample a control sequence."""

--- a/hydrax/models/crane/crane.xml
+++ b/hydrax/models/crane/crane.xml
@@ -1,6 +1,6 @@
 <mujoco>
   <!-- Simulator options -->
-  <option timestep="0.002" iterations="1" ls_iterations="5" integrator="implicitfast"/>
+  <option timestep="0.01" iterations="1" ls_iterations="5" integrator="implicitfast"/>
 
   <!-- Defaults -->
   <default>

--- a/hydrax/models/crane/crane.xml
+++ b/hydrax/models/crane/crane.xml
@@ -1,6 +1,6 @@
 <mujoco>
   <!-- Simulator options -->
-  <option timestep="0.01" iterations="1" ls_iterations="5" integrator="implicitfast"/>
+  <option timestep="0.002" iterations="1" ls_iterations="5" integrator="implicitfast"/>
 
   <!-- Defaults -->
   <default>

--- a/hydrax/models/g1/g1.xml
+++ b/hydrax/models/g1/g1.xml
@@ -1,7 +1,7 @@
 <mujoco model="g1_29dof_rev_1_0">
   <compiler angle="radian" meshdir="assets" autolimits="true"/>
 
-  <option timestep="0.01" iterations="1" ls_iterations="5">
+  <option timestep="0.02" iterations="1" ls_iterations="5">
     <flag eulerdamp="disable"/>
   </option>
 

--- a/hydrax/models/g1/g1.xml
+++ b/hydrax/models/g1/g1.xml
@@ -1,7 +1,7 @@
 <mujoco model="g1_29dof_rev_1_0">
   <compiler angle="radian" meshdir="assets" autolimits="true"/>
 
-  <option timestep="0.02" iterations="1" ls_iterations="5">
+  <option timestep="0.01" iterations="1" ls_iterations="5">
     <flag eulerdamp="disable"/>
   </option>
 

--- a/hydrax/simulation/asynchronous.py
+++ b/hydrax/simulation/asynchronous.py
@@ -155,8 +155,6 @@ def run_controller(
         policy_params = jit_optimize(mjx_data, policy_params)
 
         # Send the action to the simulator.
-        # TODO: send the full parameters rather than assuming zero-order
-        # hold and a sufficiently high control rate
         shm_data.ctrl[:] = np.array(
             get_action(policy_params, mjx_data.time), dtype=np.float32
         )

--- a/hydrax/simulation/asynchronous.py
+++ b/hydrax/simulation/asynchronous.py
@@ -118,7 +118,8 @@ def run_controller(
     # Print out some planning horizon information
     print(
         f"Planning with {ctrl.ctrl_steps} steps "
-        f"over a {ctrl.plan_horizon} second horizon."
+        f"over a {ctrl.plan_horizon} second horizon "
+        f"with {ctrl.num_knots} knots."
     )
 
     # Jit the optimizer step, then signal that we're ready to go

--- a/hydrax/simulation/asynchronous.py
+++ b/hydrax/simulation/asynchronous.py
@@ -117,8 +117,8 @@ def run_controller(
 
     # Print out some planning horizon information
     print(
-        f"Planning with {ctrl.task.planning_horizon} steps "
-        f"over a {ctrl.task.planning_horizon * ctrl.task.dt} second horizon."
+        f"Planning with {ctrl.H} steps "
+        f"over a {ctrl.H * ctrl.dt} second horizon."
     )
 
     # Jit the optimizer step, then signal that we're ready to go
@@ -160,7 +160,9 @@ def run_controller(
         )
 
         # Print the current planning frequency
-        print(f"Controller running at {1/(time.time() - st):.2f} Hz", end="\r")
+        print(
+            f"Controller running at {1 / (time.time() - st):.2f} Hz", end="\r"
+        )
 
     # Preserve the last printed line
     print("")

--- a/hydrax/simulation/asynchronous.py
+++ b/hydrax/simulation/asynchronous.py
@@ -118,7 +118,7 @@ def run_controller(
     # Print out some planning horizon information
     print(
         f"Planning with {ctrl.ctrl_steps} steps "
-        f"over a {ctrl.ctrl_steps * ctrl.dt} second horizon."
+        f"over a {ctrl.plan_horizon} second horizon."
     )
 
     # Jit the optimizer step, then signal that we're ready to go

--- a/hydrax/simulation/asynchronous.py
+++ b/hydrax/simulation/asynchronous.py
@@ -134,12 +134,14 @@ def run_controller(
     # Signal that we're ready to start
     ready.set()
 
+    start_time = time.time()
     while not finished.is_set():
-        st = time.time()
+        curr_time = time.time()
 
         # Set the start state for the controller, reading the lastest state info
         # from shared memory
         mjx_data = mjx_data.replace(
+            time=jnp.array(curr_time - start_time, dtype=jnp.float32),
             qpos=jnp.array(shm_data.qpos[:]),
             qvel=jnp.array(shm_data.qvel[:]),
         )
@@ -156,7 +158,7 @@ def run_controller(
         # TODO: send the full parameters rather than assuming zero-order
         # hold and a sufficiently high control rate
         shm_data.ctrl[:] = np.array(
-            get_action(policy_params, 0.0), dtype=np.float32
+            get_action(policy_params, mjx_data.time), dtype=np.float32
         )
 
         # Print the current planning frequency

--- a/hydrax/simulation/asynchronous.py
+++ b/hydrax/simulation/asynchronous.py
@@ -117,8 +117,8 @@ def run_controller(
 
     # Print out some planning horizon information
     print(
-        f"Planning with {ctrl.H} steps "
-        f"over a {ctrl.H * ctrl.dt} second horizon."
+        f"Planning with {ctrl.ctrl_steps} steps "
+        f"over a {ctrl.ctrl_steps * ctrl.dt} second horizon."
     )
 
     # Jit the optimizer step, then signal that we're ready to go

--- a/hydrax/simulation/deterministic.py
+++ b/hydrax/simulation/deterministic.py
@@ -79,12 +79,16 @@ def run_interactive(  # noqa: PLR0912, PLR0915
     )
     policy_params = controller.init_params()
     jit_optimize = jax.jit(controller.optimize, donate_argnums=(1,))
+    jit_get_action = jax.jit(controller.get_action)
 
     # Warm-up the controller
     print("Jitting the controller...")
     st = time.time()
     policy_params, rollouts = jit_optimize(mjx_data, policy_params)
     policy_params, rollouts = jit_optimize(mjx_data, policy_params)
+
+    u = jit_get_action(policy_params, jnp.zeros(1))
+    u = jit_get_action(policy_params, jnp.zeros(1))
     print(f"Time to jit: {time.time() - st:.3f} seconds")
     num_traces = min(rollouts.controls.shape[1], max_traces)
 
@@ -178,8 +182,9 @@ def run_interactive(  # noqa: PLR0912, PLR0915
 
             # Step the simulation
             for i in range(sim_steps_per_replan):
-                t = i * mj_model.opt.timestep
-                u = controller.get_action(policy_params, t)
+                _t = i * mj_model.opt.timestep + mj_data.time
+                t = jnp.array([_t])  # (1,)
+                u = jit_get_action(policy_params, t)
                 mj_data.ctrl[:] = np.array(u)
                 mujoco.mj_step(mj_model, mj_data)
                 viewer.sync()

--- a/hydrax/simulation/deterministic.py
+++ b/hydrax/simulation/deterministic.py
@@ -57,8 +57,8 @@ def run_interactive(  # noqa: PLR0912, PLR0915
     # Report the planning horizon in seconds for debugging
     print(
         f"Planning with {controller.ctrl_steps} steps "
-        f"over a {controller.plan_horizon} "
-        f"second horizon."
+        f"over a {controller.plan_horizon} second horizon "
+        f"with {controller.num_knots} knots."
     )
 
     # Figure out how many sim steps to run before replanning

--- a/hydrax/simulation/deterministic.py
+++ b/hydrax/simulation/deterministic.py
@@ -56,8 +56,8 @@ def run_interactive(  # noqa: PLR0912, PLR0915
     """
     # Report the planning horizon in seconds for debugging
     print(
-        f"Planning with {controller.task.H} steps "
-        f"over a {controller.task.T} "
+        f"Planning with {controller.H} steps "
+        f"over a {controller.T} "
         f"second horizon."
     )
 
@@ -110,7 +110,7 @@ def run_interactive(  # noqa: PLR0912, PLR0915
         # Set up rollout traces
         if show_traces:
             num_trace_sites = len(controller.task.trace_site_ids)
-            for i in range(num_trace_sites * num_traces * controller.task.H):
+            for i in range(num_trace_sites * num_traces * controller.H):
                 mujoco.mjv_initGeom(
                     viewer.user_scn.geoms[i],
                     type=mujoco.mjtGeom.mjGEOM_LINE,
@@ -149,7 +149,7 @@ def run_interactive(  # noqa: PLR0912, PLR0915
                 ii = 0
                 for k in range(num_trace_sites):
                     for i in range(num_traces):
-                        for j in range(controller.task.H):
+                        for j in range(controller.H):
                             mujoco.mjv_connector(
                                 viewer.user_scn.geoms[ii],
                                 mujoco.mjtGeom.mjGEOM_LINE,

--- a/hydrax/simulation/deterministic.py
+++ b/hydrax/simulation/deterministic.py
@@ -199,7 +199,6 @@ def run_interactive(  # noqa: PLR0912, PLR0915
             for i in range(sim_steps_per_replan):
                 mj_data.ctrl[:] = np.array(us[i])
                 mujoco.mj_step(mj_model, mj_data)
-                controller.task.post_step(mj_model, mj_data)
                 viewer.sync()
 
             # Try to run in roughly realtime

--- a/hydrax/simulation/deterministic.py
+++ b/hydrax/simulation/deterministic.py
@@ -56,8 +56,8 @@ def run_interactive(  # noqa: PLR0912, PLR0915
     """
     # Report the planning horizon in seconds for debugging
     print(
-        f"Planning with {controller.task.planning_horizon} steps "
-        f"over a {controller.task.planning_horizon * controller.task.dt} "
+        f"Planning with {controller.task.H} steps "
+        f"over a {controller.task.T} "
         f"second horizon."
     )
 
@@ -69,7 +69,7 @@ def run_interactive(  # noqa: PLR0912, PLR0915
     actual_frequency = 1.0 / step_dt
     print(
         f"Planning at {actual_frequency} Hz, "
-        f"simulating at {1.0/mj_model.opt.timestep} Hz"
+        f"simulating at {1.0 / mj_model.opt.timestep} Hz"
     )
 
     # Initialize the controller
@@ -110,9 +110,7 @@ def run_interactive(  # noqa: PLR0912, PLR0915
         # Set up rollout traces
         if show_traces:
             num_trace_sites = len(controller.task.trace_site_ids)
-            for i in range(
-                num_trace_sites * num_traces * controller.task.planning_horizon
-            ):
+            for i in range(num_trace_sites * num_traces * controller.task.H):
                 mujoco.mjv_initGeom(
                     viewer.user_scn.geoms[i],
                     type=mujoco.mjtGeom.mjGEOM_LINE,
@@ -151,7 +149,7 @@ def run_interactive(  # noqa: PLR0912, PLR0915
                 ii = 0
                 for k in range(num_trace_sites):
                     for i in range(num_traces):
-                        for j in range(controller.task.planning_horizon):
+                        for j in range(controller.task.H):
                             mujoco.mjv_connector(
                                 viewer.user_scn.geoms[ii],
                                 mujoco.mjtGeom.mjGEOM_LINE,

--- a/hydrax/simulation/deterministic.py
+++ b/hydrax/simulation/deterministic.py
@@ -56,8 +56,8 @@ def run_interactive(  # noqa: PLR0912, PLR0915
     """
     # Report the planning horizon in seconds for debugging
     print(
-        f"Planning with {controller.H} steps "
-        f"over a {controller.T} "
+        f"Planning with {controller.ctrl_steps} steps "
+        f"over a {controller.plan_horizon} "
         f"second horizon."
     )
 
@@ -114,7 +114,9 @@ def run_interactive(  # noqa: PLR0912, PLR0915
         # Set up rollout traces
         if show_traces:
             num_trace_sites = len(controller.task.trace_site_ids)
-            for i in range(num_trace_sites * num_traces * controller.H):
+            for i in range(
+                num_trace_sites * num_traces * controller.ctrl_steps
+            ):
                 mujoco.mjv_initGeom(
                     viewer.user_scn.geoms[i],
                     type=mujoco.mjtGeom.mjGEOM_LINE,
@@ -153,7 +155,7 @@ def run_interactive(  # noqa: PLR0912, PLR0915
                 ii = 0
                 for k in range(num_trace_sites):
                     for i in range(num_traces):
-                        for j in range(controller.H):
+                        for j in range(controller.ctrl_steps):
                             mujoco.mjv_connector(
                                 viewer.user_scn.geoms[ii],
                                 mujoco.mjtGeom.mjGEOM_LINE,

--- a/hydrax/task_base.py
+++ b/hydrax/task_base.py
@@ -22,17 +22,12 @@ class Task(ABC):
     def __init__(
         self,
         mj_model: mujoco.MjModel,
-        T: float,
-        sim_steps_per_control_step: int,
-        trace_sites: Sequence[str] = [],
-    ):
+        trace_sites: Sequence[str] | None = None,
+    ) -> None:
         """Set the model and simulation parameters.
 
         Args:
             mj_model: The MuJoCo model to use for simulation.
-            T: The time horizon for the rollout in seconds.
-            sim_steps_per_control_step: The number of simulation steps to take
-                                        for each control step.
             trace_sites: A list of site names to visualize with traces.
 
         Note: many other simulator parameters, e.g., simulator time step,
@@ -41,8 +36,6 @@ class Task(ABC):
         assert isinstance(mj_model, mujoco.MjModel)
         self.mj_model = mj_model
         self.model = mjx.put_model(mj_model)
-        self.T = T
-        self.sim_steps_per_control_step = sim_steps_per_control_step
 
         # Set actuator limits
         self.u_min = jnp.where(
@@ -56,18 +49,14 @@ class Task(ABC):
             jnp.inf,
         )
 
-        # Timestep for each control step
-        self.dt = mj_model.opt.timestep * sim_steps_per_control_step
+        # Simulation timestep
+        self.dt = mj_model.opt.timestep
 
         # Get site IDs for points we want to trace
+        trace_sites = trace_sites or []
         self.trace_site_ids = jnp.array(
             [mj_model.site(name).id for name in trace_sites]
         )
-
-    @property
-    def H(self) -> int:
-        """The number of control steps in the planning horizon."""
-        return int(round(self.T / self.dt))
 
     @abstractmethod
     def running_cost(self, state: mjx.Data, control: jax.Array) -> jax.Array:

--- a/hydrax/tasks/cart_pole.py
+++ b/hydrax/tasks/cart_pole.py
@@ -10,18 +10,12 @@ from hydrax.task_base import Task
 class CartPole(Task):
     """A cart-pole swingup task."""
 
-    def __init__(self, T: float = 1.0, sim_steps_per_control_step: int = 10):
+    def __init__(self) -> None:
         """Load the MuJoCo model and set task parameters."""
         mj_model = mujoco.MjModel.from_xml_path(
             ROOT + "/models/cart_pole/scene.xml"
         )
-
-        super().__init__(
-            mj_model,
-            T=T,
-            sim_steps_per_control_step=sim_steps_per_control_step,
-            trace_sites=["tip"],
-        )
+        super().__init__(mj_model, trace_sites=["tip"])
 
     def _distance_to_upright(self, state: mjx.Data) -> jax.Array:
         """Get a measure of distance to the upright position."""

--- a/hydrax/tasks/cart_pole.py
+++ b/hydrax/tasks/cart_pole.py
@@ -10,9 +10,7 @@ from hydrax.task_base import Task
 class CartPole(Task):
     """A cart-pole swingup task."""
 
-    def __init__(
-        self, planning_horizon: int = 10, sim_steps_per_control_step: int = 10
-    ):
+    def __init__(self, T: float = 1.0, sim_steps_per_control_step: int = 10):
         """Load the MuJoCo model and set task parameters."""
         mj_model = mujoco.MjModel.from_xml_path(
             ROOT + "/models/cart_pole/scene.xml"
@@ -20,7 +18,7 @@ class CartPole(Task):
 
         super().__init__(
             mj_model,
-            planning_horizon=planning_horizon,
+            T=T,
             sim_steps_per_control_step=sim_steps_per_control_step,
             trace_sites=["tip"],
         )

--- a/hydrax/tasks/crane.py
+++ b/hydrax/tasks/crane.py
@@ -12,20 +12,12 @@ from hydrax.task_base import Task
 class Crane(Task):
     """A luffing crane moves a payload to a target position."""
 
-    def __init__(
-        self, planning_horizon: int = 2, sim_steps_per_control_step: int = 40
-    ):
+    def __init__(self) -> None:
         """Load the MuJoCo model and set task parameters."""
         mj_model = mujoco.MjModel.from_xml_path(
             ROOT + "/models/crane/scene.xml"
         )
-
-        super().__init__(
-            mj_model,
-            planning_horizon=planning_horizon,
-            sim_steps_per_control_step=sim_steps_per_control_step,
-            trace_sites=["payload_end"],
-        )
+        super().__init__(mj_model, trace_sites=["payload_end"])
 
         self.payload_pos_sensor_adr = mj_model.sensor_adr[
             mj_model.sensor("payload_pos").id

--- a/hydrax/tasks/cube.py
+++ b/hydrax/tasks/cube.py
@@ -12,16 +12,11 @@ from hydrax.task_base import Task
 class CubeRotation(Task):
     """Cube rotation with the LEAP hand."""
 
-    def __init__(
-        self, planning_horizon: int = 3, sim_steps_per_control_step: int = 4
-    ):
+    def __init__(self) -> None:
         """Load the MuJoCo model and set task parameters."""
         mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/cube/scene.xml")
-
         super().__init__(
             mj_model,
-            planning_horizon=planning_horizon,
-            sim_steps_per_control_step=sim_steps_per_control_step,
             trace_sites=["cube_center", "if_tip", "mf_tip", "rf_tip", "th_tip"],
         )
 

--- a/hydrax/tasks/double_cart_pole.py
+++ b/hydrax/tasks/double_cart_pole.py
@@ -10,21 +10,12 @@ from hydrax.task_base import Task
 class DoubleCartPole(Task):
     """A swing-up task for a double pendulum on a cart."""
 
-    def __init__(
-        self, planning_horizon: int = 10, sim_steps_per_control_step: int = 8
-    ):
+    def __init__(self) -> None:
         """Load the MuJoCo model and set task parameters."""
         mj_model = mujoco.MjModel.from_xml_path(
             ROOT + "/models/double_cart_pole/scene.xml"
         )
-
-        super().__init__(
-            mj_model,
-            planning_horizon=planning_horizon,
-            sim_steps_per_control_step=sim_steps_per_control_step,
-            trace_sites=["tip"],
-        )
-
+        super().__init__(mj_model, trace_sites=["tip"])
         self.tip_id = mj_model.site("tip").id
 
     def _distance_to_upright(self, state: mjx.Data) -> jax.Array:

--- a/hydrax/tasks/humanoid_mocap.py
+++ b/hydrax/tasks/humanoid_mocap.py
@@ -18,23 +18,15 @@ class HumanoidMocap(Task):
     https://huggingface.co/datasets/unitreerobotics/LAFAN1_Retargeting_Dataset/.
     """
 
-    def __init__(
-        self,
-        planning_horizon: int = 4,
-        sim_steps_per_control_step: int = 5,
-        reference_filename: str = "walk1_subject1.csv",
-    ):
+    def __init__(self, reference_filename: str = "walk1_subject1.csv") -> None:
         """Load the MuJoCo model and set task parameters.
 
         The list of available reference files can be found at
         https://huggingface.co/datasets/unitreerobotics/LAFAN1_Retargeting_Dataset/tree/main/g1.
         """
         mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/g1/scene.xml")
-
         super().__init__(
             mj_model,
-            planning_horizon=planning_horizon,
-            sim_steps_per_control_step=sim_steps_per_control_step,
             trace_sites=["imu_in_torso", "left_foot", "right_foot"],
         )
 

--- a/hydrax/tasks/humanoid_standup.py
+++ b/hydrax/tasks/humanoid_standup.py
@@ -12,16 +12,11 @@ from hydrax.task_base import Task
 class HumanoidStandup(Task):
     """Standup task for the Unitree G1 humanoid."""
 
-    def __init__(
-        self, planning_horizon: int = 3, sim_steps_per_control_step: int = 10
-    ):
+    def __init__(self) -> None:
         """Load the MuJoCo model and set task parameters."""
         mj_model = mujoco.MjModel.from_xml_path(ROOT + "/models/g1/scene.xml")
-
         super().__init__(
             mj_model,
-            planning_horizon=planning_horizon,
-            sim_steps_per_control_step=sim_steps_per_control_step,
             trace_sites=["imu_in_torso", "left_foot", "right_foot"],
         )
 

--- a/hydrax/tasks/particle.py
+++ b/hydrax/tasks/particle.py
@@ -12,21 +12,12 @@ from hydrax.task_base import Task
 class Particle(Task):
     """A velocity-controlled planar point mass chases a target position."""
 
-    def __init__(
-        self, planning_horizon: int = 5, sim_steps_per_control_step: int = 5
-    ):
+    def __init__(self) -> None:
         """Load the MuJoCo model and set task parameters."""
         mj_model = mujoco.MjModel.from_xml_path(
             ROOT + "/models/particle/scene.xml"
         )
-
-        super().__init__(
-            mj_model,
-            planning_horizon=planning_horizon,
-            sim_steps_per_control_step=sim_steps_per_control_step,
-            trace_sites=["pointmass"],
-        )
-
+        super().__init__(mj_model, trace_sites=["pointmass"])
         self.pointmass_id = mj_model.site("pointmass").id
 
     def running_cost(self, state: mjx.Data, control: jax.Array) -> jax.Array:

--- a/hydrax/tasks/pendulum.py
+++ b/hydrax/tasks/pendulum.py
@@ -10,20 +10,12 @@ from hydrax.task_base import Task
 class Pendulum(Task):
     """An inverted pendulum swingup task."""
 
-    def __init__(
-        self, planning_horizon: int = 20, sim_steps_per_control_step: int = 5
-    ):
+    def __init__(self) -> None:
         """Load the MuJoCo model and set task parameters."""
         mj_model = mujoco.MjModel.from_xml_path(
             ROOT + "/models/pendulum/scene.xml"
         )
-
-        super().__init__(
-            mj_model,
-            planning_horizon=planning_horizon,
-            sim_steps_per_control_step=sim_steps_per_control_step,
-            trace_sites=["tip"],
-        )
+        super().__init__(mj_model, trace_sites=["tip"])
 
     def _distance_to_upright(self, state: mjx.Data) -> jax.Array:
         """Get a measure of distance to the upright position."""

--- a/hydrax/tasks/pusht.py
+++ b/hydrax/tasks/pusht.py
@@ -12,20 +12,12 @@ from hydrax.task_base import Task
 class PushT(Task):
     """Push a T-shaped block to a desired pose."""
 
-    def __init__(
-        self, planning_horizon: int = 5, sim_steps_per_control_step: int = 10
-    ):
+    def __init__(self) -> None:
         """Load the MuJoCo model and set task parameters."""
         mj_model = mujoco.MjModel.from_xml_path(
             ROOT + "/models/pusht/scene.xml"
         )
-
-        super().__init__(
-            mj_model,
-            planning_horizon=planning_horizon,
-            sim_steps_per_control_step=sim_steps_per_control_step,
-            trace_sites=["pusher"],
-        )
+        super().__init__(mj_model, trace_sites=["pusher"])
 
         # Get sensor ids
         self.block_position_sensor = mujoco.mj_name2id(

--- a/hydrax/tasks/walker.py
+++ b/hydrax/tasks/walker.py
@@ -10,20 +10,12 @@ from hydrax.task_base import Task
 class Walker(Task):
     """A planar biped tasked with walking forward."""
 
-    def __init__(
-        self, planning_horizon: int = 4, sim_steps_per_control_step: int = 15
-    ):
+    def __init__(self) -> None:
         """Load the MuJoCo model and set task parameters."""
         mj_model = mujoco.MjModel.from_xml_path(
             ROOT + "/models/walker/scene.xml"
         )
-
-        super().__init__(
-            mj_model,
-            planning_horizon=planning_horizon,
-            sim_steps_per_control_step=sim_steps_per_control_step,
-            trace_sites=["torso_site"],
-        )
+        super().__init__(mj_model, trace_sites=["torso_site"])
 
         # Get sensor ids
         self.torso_position_sensor = mujoco.mj_name2id(

--- a/hydrax/utils/spline.py
+++ b/hydrax/utils/spline.py
@@ -27,13 +27,13 @@ def interp_zero(tq: jax.Array, tk: jax.Array, knots: jax.Array) -> jax.Array:
 @partial(vmap, in_axes=(None, None, 0))
 def interp_linear(tq: jax.Array, tk: jax.Array, knots: jax.Array) -> jax.Array:
     """Linear spline interpolation."""
-    return interp1d(tq, tk, knots, method="linear")
+    return interp1d(tq, tk, knots, method="linear", extrap=True)
 
 
 @partial(vmap, in_axes=(None, None, 0))
 def interp_cubic(tq: jax.Array, tk: jax.Array, knots: jax.Array) -> jax.Array:
     """Cubic spline interpolation."""
-    return interp1d(tq, tk, knots, method="cubic2")
+    return interp1d(tq, tk, knots, method="cubic2", extrap=True)
 
 
 def get_interp_func(method: InterpMethodType) -> InterpFuncType:

--- a/hydrax/utils/spline.py
+++ b/hydrax/utils/spline.py
@@ -46,7 +46,7 @@ def get_interp_func(method: InterpMethodType) -> InterpFuncType:
         # we use "cubic" to mean natural splines, not local, which corresponds
         # to the "cubic2" method in interpax
         # https://github.com/f0uriest/interpax/blob/163c348925167f82a3658a094458cb2608f189ff/interpax/_spline.py#L47
-        method = "cubic" if method == "cubic" else "linear"
+        method = "cubic2" if method == "cubic" else "linear"
         interp_func = vmap(
             lambda tq, tk, knots: interp1d(tq, tk, knots, method=method),
             in_axes=(None, None, 0),

--- a/hydrax/utils/spline.py
+++ b/hydrax/utils/spline.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Callable, Literal
 
 import jax
@@ -7,6 +8,32 @@ from jax import vmap
 
 InterpMethodType = Literal["zero", "linear", "cubic"]
 InterpFuncType = Callable[[jax.Array, jax.Array, jax.Array], jax.Array]
+
+
+"""We define the interpolation functions here so they're picklable for async."""
+
+
+@partial(vmap, in_axes=(None, None, 0))
+def interp_zero(tq: jax.Array, tk: jax.Array, knots: jax.Array) -> jax.Array:
+    """Zero-order spline interpolation."""
+    # for a zero-order spline, take the "next" knot as the control
+    # ex: tq = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5]
+    #     tk = [0.0, 0.25, 0.5]
+    #     inds = [0, 0, 0, 1, 1, 2]  # searchsorted trick does this
+    #     interp_func(tq, tk, knots) = knots[:, inds]
+    return knots[jnp.searchsorted(tk, tq, side="right") - 1]
+
+
+@partial(vmap, in_axes=(None, None, 0))
+def interp_linear(tq: jax.Array, tk: jax.Array, knots: jax.Array) -> jax.Array:
+    """Linear spline interpolation."""
+    return interp1d(tq, tk, knots, method="linear")
+
+
+@partial(vmap, in_axes=(None, None, 0))
+def interp_cubic(tq: jax.Array, tk: jax.Array, knots: jax.Array) -> jax.Array:
+    """Cubic spline interpolation."""
+    return interp1d(tq, tk, knots, method="cubic2")
 
 
 def get_interp_func(method: InterpMethodType) -> InterpFuncType:
@@ -31,26 +58,11 @@ def get_interp_func(method: InterpMethodType) -> InterpFuncType:
         interp_func: The interpolation function.
     """
     if method == "zero":
-        # for a zero-order spline, take the "next" knot as the control
-        # ex: tq = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5]
-        #     tk = [0.0, 0.25, 0.5]
-        #     inds = [0, 0, 0, 1, 1, 2]  # searchsorted trick does this
-        #     interp_func(tq, tk, knots) = knots[:, inds]
-        interp_func = vmap(
-            lambda tq, tk, knots: knots[
-                jnp.searchsorted(tk, tq, side="right") - 1
-            ],
-            in_axes=(None, None, 0),
-        )
-    elif method in ["linear", "cubic"]:
-        # we use "cubic" to mean natural splines, not local, which corresponds
-        # to the "cubic2" method in interpax
-        # https://github.com/f0uriest/interpax/blob/163c348925167f82a3658a094458cb2608f189ff/interpax/_spline.py#L47
-        method = "cubic2" if method == "cubic" else "linear"
-        interp_func = vmap(
-            lambda tq, tk, knots: interp1d(tq, tk, knots, method=method),
-            in_axes=(None, None, 0),
-        )
+        interp_func = interp_zero
+    elif method == "linear":
+        interp_func = interp_linear
+    elif method == "cubic":
+        interp_func = interp_cubic
     else:
         raise ValueError(
             f"Unknown interpolation method: {method}. "

--- a/hydrax/utils/spline.py
+++ b/hydrax/utils/spline.py
@@ -1,0 +1,59 @@
+from typing import Callable, Literal
+
+import jax
+import jax.numpy as jnp
+from interpax import interp1d
+from jax import vmap
+
+InterpMethodType = Literal["zero", "linear", "cubic"]
+InterpFuncType = Callable[[jax.Array, jax.Array, jax.Array], jax.Array]
+
+
+def get_interp_func(method: InterpMethodType) -> InterpFuncType:
+    """Get the 1D interpolation function based on the specified method.
+
+    In particular, the function will have signature
+        u_traj = interp_func(tq, tk, knots),
+    where
+        * tq is a 1D array of query times of shape (H,)
+        * tk is a 1D array of knot times of shape (num_knots,),
+        * knots is an array of shape (num_rollouts, num_knots), and
+        * u_traj is the batch of interpolated trajectories of shape
+            (num_rollouts, H).
+    Here, we expect H to be the number of control time steps over some horizon T
+    in seconds.
+
+    Args:
+        method: The interpolation method to use. Can be "zero", "linear", or
+            "cubic".
+
+    Returns:
+        interp_func: The interpolation function.
+    """
+    if method == "zero":
+        # for a zero-order spline, take the "next" knot as the control
+        # ex: tq = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5]
+        #     tk = [0.0, 0.25, 0.5]
+        #     inds = [0, 0, 0, 1, 1, 2]  # searchsorted trick does this
+        #     interp_func(tq, tk, knots) = knots[:, inds]
+        interp_func = vmap(
+            lambda tq, tk, knots: knots[
+                jnp.searchsorted(tk, tq, side="right") - 1
+            ],
+            in_axes=(None, None, 0),
+        )
+    elif method in ["linear", "cubic"]:
+        # we use "cubic" to mean natural splines, not local, which corresponds
+        # to the "cubic2" method in interpax
+        # https://github.com/f0uriest/interpax/blob/163c348925167f82a3658a094458cb2608f189ff/interpax/_spline.py#L47
+        method = "cubic" if method == "cubic" else "linear"
+        interp_func = vmap(
+            lambda tq, tk, knots: interp1d(tq, tk, knots, method=method),
+            in_axes=(None, None, 0),
+        )
+    else:
+        raise ValueError(
+            f"Unknown interpolation method: {method}. "
+            "Expected one of ['zero', 'linear', 'cubic']."
+        )
+    return interp_func

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,16 +14,20 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dependencies = [
-    "jax[cuda12]==0.4.35",
-    "flax==0.10.0",
-    "pytest==8.3.3",
-    "ruff==0.7.1",
-    "pre-commit==4.0.1",
-    "matplotlib==3.9.2",
-    "mujoco==3.2.4",
-    "mujoco-mjx==3.2.4",
-    "evosax==0.1.6",
-    "huggingface_hub==0.29.3",
+    "evosax>=0.1.6",
+    "flax>=0.10.0",
+    "huggingface_hub>=0.29.3",
+    "jax[cuda12]>=0.4.35",
+    "mujoco>=3.2.4",
+    "mujoco-mjx>=3.2.4",
+]
+
+[project.optional-dependencies]
+dev = [
+    "matplotlib>=3.9.2",
+    "pre-commit>=4.0.1",
+    "pytest>=8.3.3",
+    "ruff>=0.7.1",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,6 @@ ignore = [
     "D212",  # multi-line docstring summary at first line
     "D213",  # multi-line docstring summary at second line
     "E731",  # assigning to a `lambda` expression
-    "N802",  # function name should be lowercase
-    "N803",  # argument name should be lowercase
     "N806",  # only lowercase variables in functions
     "PLR0913",  # too many arguments
     "PLR2004",  # magic value used in comparison

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,9 @@ classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python",
 ]
+# TODO: evosax v0.2.0 introduced many breaking changes in the API that cause test failures
 dependencies = [
-    "evosax>=0.1.6",
+    "evosax<0.2.0",
     "flax>=0.10.0",
     "huggingface_hub>=0.29.3",
     "jax[cuda12]>=0.4.35",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ ignore = [
     "D212",  # multi-line docstring summary at first line
     "D213",  # multi-line docstring summary at second line
     "E731",  # assigning to a `lambda` expression
-    "N802",  # function name `H` should be lowercase
+    "N802",  # function name should be lowercase
     "N803",  # argument name should be lowercase
     "N806",  # only lowercase variables in functions
     "PLR0913",  # too many arguments

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "hydrax"
-version = "0.0.1"
+version = "0.0.2"
 description = "Sampling-based model predictive control on GPU with JAX/MJX"
 readme = "README.md"
 license = {text="MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "evosax<0.2.0",
     "flax>=0.10.0",
     "huggingface_hub>=0.29.3",
+    "interpax>=0.3.7",
     "jax[cuda12]>=0.4.35",
     "mujoco>=3.2.4",
     "mujoco-mjx>=3.2.4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ select = [
 ]
 ignore = [
     "ANN003",  # missing type annotation for **kwargs
-    "ANN101",  # missing type annotation for `self` in method
     "ANN202",  # missing return type annotation for private function
     "ANN204",  # missing return type annotation for `__init__`
     "ANN401",  # dynamically typed expressions (typing.Any) are disallowed
@@ -63,6 +62,8 @@ ignore = [
     "D212",  # multi-line docstring summary at first line
     "D213",  # multi-line docstring summary at second line
     "E731",  # assigning to a `lambda` expression
+    "N802",  # function name `H` should be lowercase
+    "N803",  # argument name should be lowercase
     "N806",  # only lowercase variables in functions
     "PLR0913",  # too many arguments
     "PLR2004",  # magic value used in comparison

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ ignore = [
 
 [tool.ruff.lint.isort]
 combine-as-imports = true
-known-first-party = ["hydra"]
+known-first-party = ["hydrax"]
 split-on-trailing-comma = false
 
 [tool.ruff.format]

--- a/tests/test_alg_base.py
+++ b/tests/test_alg_base.py
@@ -5,12 +5,13 @@ from hydrax.alg_base import Trajectory
 
 def test_traj() -> None:
     """Make sure we can define a Trajectory object."""
-    batch, horizon = 5, 10
+    batch, horizon, num_knots = 5, 10, 3
     U = jnp.zeros((batch, horizon, 3))
+    K = jnp.zeros((batch, num_knots, 3))
     J = jnp.zeros((batch, horizon + 1))
     P = jnp.zeros((batch, horizon + 1, 0, 3))
 
-    traj = Trajectory(controls=U, costs=J, trace_sites=P)
+    traj = Trajectory(controls=U, knots=K, costs=J, trace_sites=P)
     assert len(traj) == horizon
 
 

--- a/tests/test_cem.py
+++ b/tests/test_cem.py
@@ -34,8 +34,9 @@ def test_open_loop() -> None:
 
     # Roll out the solution, check that it's good enough
     knots = params.mean[None]
+    tk = jnp.linspace(0.0, opt.T, opt.num_knots)  # knot times
     tq = jnp.linspace(0.0, opt.T - opt.dt, opt.H)  # ctrl query times
-    controls = opt.interp_func(tq, opt.tk, knots)
+    controls = opt.interp_func(tq, tk, knots)
     states, final_rollout = jax.jit(opt.eval_rollouts)(
         task.model, state, controls, knots
     )

--- a/tests/test_cem.py
+++ b/tests/test_cem.py
@@ -12,7 +12,15 @@ def test_open_loop() -> None:
     # Task and optimizer setup
     task = Pendulum()
     opt = CEM(
-        task, num_samples=32, num_elites=4, sigma_start=1.0, sigma_min=0.1
+        task,
+        num_samples=32,
+        num_elites=4,
+        sigma_start=1.0,
+        sigma_min=0.1,
+        T=1.0,
+        dt=0.1,
+        spline_type="zero",
+        num_knots=11,
     )
     jit_opt = jax.jit(opt.optimize)
 
@@ -22,11 +30,14 @@ def test_open_loop() -> None:
 
     for _ in range(100):
         # Do an optimization step
-        params, _ = jit_opt(state, params)
+        params, rollouts = jit_opt(state, params)
 
     # Roll out the solution, check that it's good enough
+    knots = params.mean[None]
+    tq = jnp.linspace(0.0, opt.T - opt.dt, opt.H)  # ctrl query times
+    controls = opt.interp_func(tq, opt.tk, knots)
     states, final_rollout = jax.jit(opt.eval_rollouts)(
-        task.model, state, params.mean[None]
+        task.model, state, controls, knots
     )
     theta = states.qpos[0, :, 0]
     theta_dot = states.qvel[0, :, 0]
@@ -38,7 +49,7 @@ def test_open_loop() -> None:
     if __name__ == "__main__":
         # Plot the solution
         _, ax = plt.subplots(3, 1, sharex=True)
-        times = jnp.arange(task.planning_horizon) * task.dt
+        times = jnp.arange(opt.H) * task.dt
 
         ax[0].plot(times, theta)
         ax[0].set_ylabel(r"$\theta$")

--- a/tests/test_cem.py
+++ b/tests/test_cem.py
@@ -17,8 +17,7 @@ def test_open_loop() -> None:
         num_elites=4,
         sigma_start=1.0,
         sigma_min=0.1,
-        T=1.0,
-        dt=0.1,
+        plan_horizon=1.0,
         spline_type="zero",
         num_knots=11,
     )
@@ -34,8 +33,8 @@ def test_open_loop() -> None:
 
     # Roll out the solution, check that it's good enough
     knots = params.mean[None]
-    tk = jnp.linspace(0.0, opt.T, opt.num_knots)  # knot times
-    tq = jnp.linspace(0.0, opt.T - opt.dt, opt.H)  # ctrl query times
+    tk = jnp.linspace(0.0, opt.plan_horizon, opt.num_knots)
+    tq = jnp.linspace(0.0, opt.plan_horizon - opt.dt, opt.ctrl_steps)
     controls = opt.interp_func(tq, tk, knots)
     states, final_rollout = jax.jit(opt.eval_rollouts)(
         task.model, state, controls, knots
@@ -50,7 +49,7 @@ def test_open_loop() -> None:
     if __name__ == "__main__":
         # Plot the solution
         _, ax = plt.subplots(3, 1, sharex=True)
-        times = jnp.arange(opt.H) * task.dt
+        times = jnp.arange(opt.ctrl_steps) * task.dt
 
         ax[0].plot(times, theta)
         ax[0].set_ylabel(r"$\theta$")

--- a/tests/test_cma_es.py
+++ b/tests/test_cma_es.py
@@ -30,8 +30,9 @@ def test_cmaes() -> None:
     knots, params = ctrl.sample_knots(params)
     assert knots.shape == (32, ctrl.num_knots, 1)
 
+    tk = jnp.linspace(0.0, ctrl.T, ctrl.num_knots)  # knot times
     tq = jnp.linspace(0.0, ctrl.T - ctrl.dt, ctrl.H)  # ctrl query times
-    controls = ctrl.interp_func(tq, ctrl.tk, knots)
+    controls = ctrl.interp_func(tq, tk, knots)
 
     # Roll out the control sequences
     state = mjx.make_data(task.model)
@@ -72,8 +73,9 @@ def test_open_loop() -> None:
     # Pick the best rollout
     best_cost = params.opt_state.best_fitness
     best_knots = params.mean[None]
+    tk = jnp.linspace(0.0, opt.T, opt.num_knots)  # knot times
     tq = jnp.linspace(0.0, opt.T - opt.dt, opt.H)  # ctrl query times
-    controls = opt.interp_func(tq, opt.tk, best_knots)
+    controls = opt.interp_func(tq, tk, best_knots)
     states, final_rollout = jax.jit(opt.eval_rollouts)(
         task.model, state, controls, best_knots
     )

--- a/tests/test_cma_es.py
+++ b/tests/test_cma_es.py
@@ -19,7 +19,7 @@ def test_cmaes() -> None:
     assert params.opt_state.weights.shape == (32,)
 
     # Sample control sequences from the policy
-    controls, params = ctrl.sample_controls(params)
+    controls, params = ctrl.sample_knots(params)
     assert controls.shape == (32, 20, 1)
 
     # Roll out the control sequences

--- a/tests/test_dr.py
+++ b/tests/test_dr.py
@@ -49,8 +49,8 @@ def test_opt() -> None:
     params, rollouts = ctrl.optimize(state, params)
 
     # Check the rollout shapes. Should be still be (samples, timestep, ...)
-    assert rollouts.costs.shape == (10, ctrl.H + 1)
-    assert rollouts.controls.shape == (10, ctrl.H, 2)
+    assert rollouts.costs.shape == (10, ctrl.ctrl_steps + 1)
+    assert rollouts.controls.shape == (10, ctrl.ctrl_steps, 2)
     assert rollouts.knots.shape == (10, ctrl.num_knots, 2)
 
     # Check the updated parameters

--- a/tests/test_dr.py
+++ b/tests/test_dr.py
@@ -33,7 +33,11 @@ def test_opt() -> None:
     """Test optimization with domain randomization for the particle."""
     task = Particle()
     ctrl = PredictiveSampling(
-        task, num_samples=10, noise_level=0.1, num_randomizations=3
+        task,
+        num_samples=10,
+        noise_level=0.1,
+        num_randomizations=3,
+        num_knots=7,
     )
     params = ctrl.init_params()
 
@@ -45,11 +49,12 @@ def test_opt() -> None:
     params, rollouts = ctrl.optimize(state, params)
 
     # Check the rollout shapes. Should be still be (samples, timestep, ...)
-    assert rollouts.costs.shape == (10, 6)
-    assert rollouts.controls.shape == (10, 5, 2)
+    assert rollouts.costs.shape == (10, ctrl.H + 1)
+    assert rollouts.controls.shape == (10, ctrl.H, 2)
+    assert rollouts.knots.shape == (10, ctrl.num_knots, 2)
 
     # Check the updated parameters
-    assert params.mean.shape == (5, 2)
+    assert params.mean.shape == (ctrl.num_knots, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_mppi.py
+++ b/tests/test_mppi.py
@@ -32,8 +32,9 @@ def test_open_loop() -> None:
         params, _ = jit_opt(state, params)
 
     knots = params.mean[None]
+    tk = jnp.linspace(0.0, opt.T, opt.num_knots)  # knot times
     tq = jnp.linspace(0.0, opt.T - opt.dt, opt.H)  # ctrl query times
-    controls = opt.interp_func(tq, opt.tk, knots)
+    controls = opt.interp_func(tq, tk, knots)
 
     # Roll out the solution, check that it's good enough
     states, final_rollout = jax.jit(opt.eval_rollouts)(

--- a/tests/test_mppi.py
+++ b/tests/test_mppi.py
@@ -11,7 +11,16 @@ def test_open_loop() -> None:
     """Use MPPI for open-loop pendulum swingup."""
     # Task and optimizer setup
     task = Pendulum()
-    opt = MPPI(task, num_samples=32, noise_level=0.1, temperature=0.01)
+    opt = MPPI(
+        task,
+        num_samples=32,
+        noise_level=0.1,
+        temperature=0.01,
+        T=1.0,
+        dt=0.1,
+        spline_type="zero",
+        num_knots=11,
+    )
     jit_opt = jax.jit(opt.optimize)
 
     # Initialize the system state and policy parameters
@@ -22,9 +31,13 @@ def test_open_loop() -> None:
         # Do an optimization step
         params, _ = jit_opt(state, params)
 
+    knots = params.mean[None]
+    tq = jnp.linspace(0.0, opt.T - opt.dt, opt.H)  # ctrl query times
+    controls = opt.interp_func(tq, opt.tk, knots)
+
     # Roll out the solution, check that it's good enough
     states, final_rollout = jax.jit(opt.eval_rollouts)(
-        task.model, state, params.mean[None]
+        task.model, state, controls, knots
     )
     total_cost = jnp.sum(final_rollout.costs[0])
     assert total_cost <= 9.0
@@ -32,7 +45,7 @@ def test_open_loop() -> None:
     if __name__ == "__main__":
         # Plot the solution
         _, ax = plt.subplots(3, 1, sharex=True)
-        times = jnp.arange(task.planning_horizon) * task.dt
+        times = jnp.arange(opt.H) * task.dt
 
         ax[0].plot(times, states.qpos[0, :, 0])
         ax[0].set_ylabel(r"$\theta$")

--- a/tests/test_mppi.py
+++ b/tests/test_mppi.py
@@ -16,8 +16,7 @@ def test_open_loop() -> None:
         num_samples=32,
         noise_level=0.1,
         temperature=0.01,
-        T=1.0,
-        dt=0.1,
+        plan_horizon=1.0,
         spline_type="zero",
         num_knots=11,
     )
@@ -32,8 +31,8 @@ def test_open_loop() -> None:
         params, _ = jit_opt(state, params)
 
     knots = params.mean[None]
-    tk = jnp.linspace(0.0, opt.T, opt.num_knots)  # knot times
-    tq = jnp.linspace(0.0, opt.T - opt.dt, opt.H)  # ctrl query times
+    tk = jnp.linspace(0.0, opt.plan_horizon, opt.num_knots)
+    tq = jnp.linspace(0.0, opt.plan_horizon - opt.dt, opt.ctrl_steps)
     controls = opt.interp_func(tq, tk, knots)
 
     # Roll out the solution, check that it's good enough
@@ -46,7 +45,7 @@ def test_open_loop() -> None:
     if __name__ == "__main__":
         # Plot the solution
         _, ax = plt.subplots(3, 1, sharex=True)
-        times = jnp.arange(opt.H) * task.dt
+        times = jnp.arange(opt.ctrl_steps) * task.dt
 
         ax[0].plot(times, states.qpos[0, :, 0])
         ax[0].set_ylabel(r"$\theta$")

--- a/tests/test_predictive_sampling.py
+++ b/tests/test_predictive_sampling.py
@@ -18,7 +18,7 @@ def test_predictive_sampling() -> None:
     assert isinstance(params.rng, jax._src.prng.PRNGKeyArray)
 
     # Sample control sequences from the policy
-    controls, new_params = opt.sample_controls(params)
+    controls, new_params = opt.sample_knots(params)
     assert controls.shape == (opt.num_samples, task.planning_horizon, 1)
     assert new_params.rng != params.rng
 

--- a/tests/test_predictive_sampling.py
+++ b/tests/test_predictive_sampling.py
@@ -10,41 +10,57 @@ from hydrax.tasks.pendulum import Pendulum
 def test_predictive_sampling() -> None:
     """Test the PredictiveSampling algorithm."""
     task = Pendulum()
-    opt = PredictiveSampling(task, num_samples=32, noise_level=0.1)
+    opt = PredictiveSampling(
+        task,
+        num_samples=32,
+        noise_level=0.1,
+        T=1.0,
+        dt=0.1,
+        spline_type="zero",
+        num_knots=11,
+    )
 
     # Initialize the policy parameters
     params = opt.init_params()
-    assert params.mean.shape == (task.planning_horizon, 1)
+    assert params.mean.shape == (opt.num_knots, 1)
     assert isinstance(params.rng, jax._src.prng.PRNGKeyArray)
 
     # Sample control sequences from the policy
-    controls, new_params = opt.sample_knots(params)
-    assert controls.shape == (opt.num_samples, task.planning_horizon, 1)
+    knots, new_params = opt.sample_knots(params)
+    tq = jnp.linspace(0.0, opt.T - opt.dt, opt.H)  # ctrl query times
+    controls = opt.interp_func(tq, opt.tk, knots)
+    assert controls.shape == (opt.num_samples, opt.H, 1)
+    assert knots.shape == (opt.num_samples, opt.num_knots, 1)
     assert new_params.rng != params.rng
 
     # Roll out the control sequences
     state = mjx.make_data(task.model)
-    _, rollouts = opt.eval_rollouts(task.model, state, controls)
+    _, rollouts = opt.eval_rollouts(task.model, state, controls, knots)
 
     assert rollouts.costs.shape == (
         opt.num_samples,
-        task.planning_horizon + 1,
+        opt.H + 1,
     )
     assert rollouts.controls.shape == (
         opt.num_samples,
-        task.planning_horizon,
+        opt.H,
+        1,
+    )
+    assert rollouts.knots.shape == (
+        opt.num_samples,
+        opt.num_knots,
         1,
     )
     assert rollouts.trace_sites.shape == (
         opt.num_samples,
-        task.planning_horizon + 1,
+        opt.H + 1,
         len(task.trace_site_ids),
         3,
     )
 
     # Pick the best rollout
     updated_params = opt.update_params(new_params, rollouts)
-    assert updated_params.mean.shape == (task.planning_horizon, 1)
+    assert updated_params.mean.shape == (opt.num_knots, 1)
     assert jnp.all(updated_params.mean != new_params.mean)
 
 
@@ -52,7 +68,15 @@ def test_open_loop() -> None:
     """Use predictive sampling for open-loop optimization."""
     # Task and optimizer setup
     task = Pendulum()
-    opt = PredictiveSampling(task, num_samples=32, noise_level=0.1)
+    opt = PredictiveSampling(
+        task,
+        num_samples=32,
+        noise_level=0.1,
+        T=1.0,
+        dt=0.1,
+        spline_type="zero",
+        num_knots=11,
+    )
     jit_opt = jax.jit(opt.optimize)
 
     # Initialize the system state and policy parameters
@@ -67,14 +91,17 @@ def test_open_loop() -> None:
     total_costs = jnp.sum(rollouts.costs, axis=1)
     best_idx = jnp.argmin(total_costs)
     best_ctrl = rollouts.controls[best_idx]
+    best_knots = rollouts.knots[best_idx]
     assert total_costs[best_idx] <= 9.0
 
-    states, _ = jax.jit(opt.eval_rollouts)(task.model, state, best_ctrl[None])
+    states, _ = jax.jit(opt.eval_rollouts)(
+        task.model, state, best_ctrl[None], best_knots[None]
+    )
 
     if __name__ == "__main__":
         # Plot the solution
         _, ax = plt.subplots(3, 1, sharex=True)
-        times = jnp.arange(task.planning_horizon) * task.dt
+        times = jnp.arange(opt.H) * task.dt
 
         ax[0].plot(times, states.qpos[0, :, 0])
         ax[0].set_ylabel(r"$\theta$")

--- a/tests/test_predictive_sampling.py
+++ b/tests/test_predictive_sampling.py
@@ -27,8 +27,9 @@ def test_predictive_sampling() -> None:
 
     # Sample control sequences from the policy
     knots, new_params = opt.sample_knots(params)
+    tk = jnp.linspace(0.0, opt.T, opt.num_knots)  # knot times
     tq = jnp.linspace(0.0, opt.T - opt.dt, opt.H)  # ctrl query times
-    controls = opt.interp_func(tq, opt.tk, knots)
+    controls = opt.interp_func(tq, tk, knots)
     assert controls.shape == (opt.num_samples, opt.H, 1)
     assert knots.shape == (opt.num_samples, opt.num_knots, 1)
     assert new_params.rng != params.rng

--- a/tests/test_spline.py
+++ b/tests/test_spline.py
@@ -1,0 +1,67 @@
+import jax.numpy as jnp
+import pytest
+
+from hydrax.utils.spline import get_interp_func
+
+
+def test_zero_interp_func() -> None:
+    """Tests the correctness of the zero-order interpolation function."""
+    func = get_interp_func("zero")
+
+    tq = jnp.linspace(0.0, 1.0, 11)
+    tk = jnp.array([0.0, 0.5, 1.0])
+    knots = jnp.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]])
+
+    out = func(tq, tk, knots)
+    expected = jnp.array(
+        [
+            [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0, 2.0],
+            [3.0, 3.0, 3.0, 3.0, 3.0, 4.0, 4.0, 4.0, 4.0, 4.0, 5.0],
+        ]
+    )
+    assert jnp.allclose(out, expected), f"Expected {expected}, got {out}!"
+
+
+def test_linear_interp_func() -> None:
+    """Tests the correctness of the linear interpolation function."""
+    func = get_interp_func("linear")
+
+    tq = jnp.linspace(0.0, 1.0, 11)
+    tk = jnp.array([0.0, 0.5, 1.0])
+    knots = jnp.array([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]])
+
+    out = func(tq, tk, knots)
+    expected = jnp.array(
+        [
+            [0.0, 0.2, 0.4, 0.6, 0.8, 1.0, 1.2, 1.4, 1.6, 1.8, 2.0],
+            [3.0, 3.2, 3.4, 3.6, 3.8, 4.0, 4.2, 4.4, 4.6, 4.8, 5.0],
+        ]
+    )
+    assert jnp.allclose(out, expected), f"Expected {expected}, got {out}!"
+
+
+@pytest.mark.skip(reason="Failure due to interpax bug.")
+def test_cubic_interp_func() -> None:
+    """Tests the correctness of the cubic interpolation function.
+
+    NOTE: this test is currently failing, but I think there's some deep bug in
+    the interp1d implementation. See this open issue I opened:
+    https://github.com/f0uriest/interpax/issues/87
+    """
+    func = get_interp_func("cubic")
+
+    tq = jnp.linspace(0.0, 2.0 * jnp.pi, 10001)
+    tk = jnp.linspace(0.0, 2.0 * jnp.pi, 101)
+    f = lambda x: jnp.stack([jnp.sin(x), jnp.cos(x)], axis=0)
+    knots = f(tk)
+    out = func(tq, tk, knots)
+    assert jnp.allclose(out, f(tq), rtol=1e-6, atol=1e-5), (
+        f"Expected {f(tq)}, got {out}!"
+    )
+
+
+if __name__ == "__main__":
+    test_zero_interp_func()
+    test_linear_interp_func()
+    test_cubic_interp_func()
+    print("All tests passed!")


### PR DESCRIPTION
This PR aims to add general support for zero-order, linear, and cubic splines to `hydrax`.

Changes:
* Basic changes to task API to specify time horizon in seconds instead of steps. Also moves all time-based variables into the controller instead of the task.
* Updated control updated logic to operate on knots instead of control steps + exposed three spline types: zero, linear, and cubic.
* Updated all tasks + PS, CEM, MPPI, and Evosax implementations to be compliant with new spline API.
* Tests for correctness of spline code.
    * NOTE: there's currently a potential bug in the cubic spline interpolation logic in `interpax` in the case when `nu>1` (so nearly always). The magnitude of the error is fairly minor, so cubic splines should still work OK for our purposes, but we should track the issue [here](https://github.com/f0uriest/interpax/issues/87).
* Updated all existing tests.

TODOs in future PRs as per slack discussion:
* expose a separate xml for the simulation, and currently always interpret `task.model` as the controller's internal model of the system. See #43.
* Handroll cubic spline support instead of relying on `interpax`. See #44.
* Fix slow viz induced by typically more traces. See #47.