### PR TITLE
Enable JAX persistent compilation cache

### DIFF
--- a/hydrax/__init__.py
+++ b/hydrax/__init__.py
@@ -1,4 +1,5 @@
 import os
+import jax
 from pathlib import Path
 
 # package root
@@ -6,3 +7,6 @@ ROOT = str(Path(__file__).parent.absolute())
 
 # Set XLA flags for better performance
 os.environ["XLA_FLAGS"] = "--xla_gpu_triton_gemm_any=true "
+
+# Enable persistent compilation cache
+jax.config.update("jax_compilation_cache_dir", "/tmp/jax_cache")


### PR DESCRIPTION
This PR enables JAX's [persistent compilation cache](https://docs.jax.dev/en/latest/persistent_compilation_cache.html).

Reduces time to JIT controller by around 2x on my system after compiling once. 

Before cache (`humanoid_standup.py`): Time to jit: 39.165 seconds
After cached (`humanoid_standup.py`): Time to jit: 18.257 seconds

Any change to controller, like tuning parameters, will result in cache not being utilized but this is still nice to have.