### PR TITLE
Add ability to set the initial mean of policy params

### DIFF
--- a/hydrax/alg_base.py
+++ b/hydrax/alg_base.py
@@ -252,17 +252,24 @@ class SamplingBasedController(ABC):
             trace_sites=trace_sites,
         )
 
-    def init_params(self, seed: int = 0) -> Any:
+    def init_params(
+        self, initial_control: jax.Array = None, seed: int = 0
+    ) -> Any:
         """Initialize the policy parameters, U = [u₀, u₁, ... ] ~ π(params).
 
         Args:
+            initial_control: The initial knots of the control spline.
             seed: The random seed for initializing the policy parameters.
 
         Returns:
             The initial policy parameters.
         """
         rng = jax.random.key(seed)
-        mean = jnp.zeros((self.num_knots, self.task.model.nu))
+        mean = (
+            initial_control
+            if initial_control is not None
+            else jnp.zeros((self.num_knots, self.task.model.nu))
+        )
         tk = jnp.linspace(0.0, self.plan_horizon, self.num_knots)
         return SamplingParams(tk=tk, mean=mean, rng=rng)
 

--- a/hydrax/alg_base.py
+++ b/hydrax/alg_base.py
@@ -270,10 +270,9 @@ class SamplingBasedController(ABC):
             if initial_knots is not None
             else jnp.zeros((self.num_knots, self.task.model.nu))
         )
-        if initial_knots is not None:
-            assert mean.shape == (self.num_knots, self.task.model.nu), (
-                f"Initial knots must have shape (num_knots, nu), got {mean.shape}"
-            )
+        assert mean.shape == (self.num_knots, self.task.model.nu), (
+            f"Initial knots must have shape (num_knots, nu), got {mean.shape}"
+        )
         tk = jnp.linspace(0.0, self.plan_horizon, self.num_knots)
         return SamplingParams(tk=tk, mean=mean, rng=rng)
 

--- a/hydrax/alg_base.py
+++ b/hydrax/alg_base.py
@@ -270,6 +270,10 @@ class SamplingBasedController(ABC):
             if initial_control is not None
             else jnp.zeros((self.num_knots, self.task.model.nu))
         )
+        if initial_control is not None:
+            assert mean.shape == (self.num_knots, self.task.model.nu), (
+                f"Initial control must have shape (num_knots, nu), got {mean.shape}"
+            )
         tk = jnp.linspace(0.0, self.plan_horizon, self.num_knots)
         return SamplingParams(tk=tk, mean=mean, rng=rng)
 

--- a/hydrax/alg_base.py
+++ b/hydrax/alg_base.py
@@ -253,12 +253,12 @@ class SamplingBasedController(ABC):
         )
 
     def init_params(
-        self, initial_control: jax.Array = None, seed: int = 0
+        self, initial_knots: jax.Array = None, seed: int = 0
     ) -> Any:
         """Initialize the policy parameters, U = [u₀, u₁, ... ] ~ π(params).
 
         Args:
-            initial_control: The initial knots of the control spline.
+            initial_knots: The initial knots of the control spline.
             seed: The random seed for initializing the policy parameters.
 
         Returns:
@@ -266,13 +266,13 @@ class SamplingBasedController(ABC):
         """
         rng = jax.random.key(seed)
         mean = (
-            initial_control
-            if initial_control is not None
+            initial_knots
+            if initial_knots is not None
             else jnp.zeros((self.num_knots, self.task.model.nu))
         )
-        if initial_control is not None:
+        if initial_knots is not None:
             assert mean.shape == (self.num_knots, self.task.model.nu), (
-                f"Initial control must have shape (num_knots, nu), got {mean.shape}"
+                f"Initial knots must have shape (num_knots, nu), got {mean.shape}"
             )
         tk = jnp.linspace(0.0, self.plan_horizon, self.num_knots)
         return SamplingParams(tk=tk, mean=mean, rng=rng)

--- a/hydrax/algs/cem.py
+++ b/hydrax/algs/cem.py
@@ -79,10 +79,10 @@ class CEM(SamplingBasedController):
         self.num_explore = int(self.num_samples * explore_fraction)
 
     def init_params(
-        self, initial_control: jax.Array = None, seed: int = 0
+        self, initial_knots: jax.Array = None, seed: int = 0
     ) -> CEMParams:
         """Initialize the policy parameters."""
-        _params = super().init_params(initial_control, seed)
+        _params = super().init_params(initial_knots, seed)
         cov = jnp.full_like(_params.mean, self.sigma_start)
         return CEMParams(
             tk=_params.tk, mean=_params.mean, cov=cov, rng=_params.rng

--- a/hydrax/algs/cem.py
+++ b/hydrax/algs/cem.py
@@ -78,9 +78,11 @@ class CEM(SamplingBasedController):
         self.num_elites = num_elites
         self.num_explore = int(self.num_samples * explore_fraction)
 
-    def init_params(self, seed: int = 0) -> CEMParams:
+    def init_params(
+        self, initial_control: jax.Array = None, seed: int = 0
+    ) -> CEMParams:
         """Initialize the policy parameters."""
-        _params = super().init_params(seed)
+        _params = super().init_params(initial_control, seed)
         cov = jnp.full_like(_params.mean, self.sigma_start)
         return CEMParams(
             tk=_params.tk, mean=_params.mean, cov=cov, rng=_params.rng

--- a/hydrax/algs/evosax.py
+++ b/hydrax/algs/evosax.py
@@ -87,10 +87,10 @@ class Evosax(SamplingBasedController):
         self.es_params = es_params
 
     def init_params(
-        self, initial_control: jax.Array = None, seed: int = 0
+        self, initial_knots: jax.Array = None, seed: int = 0
     ) -> EvosaxParams:
         """Initialize the policy parameters."""
-        _params = super().init_params(initial_control, seed)
+        _params = super().init_params(initial_knots, seed)
         rng, init_rng = jax.random.split(_params.rng)
         opt_state = self.strategy.initialize(init_rng, self.es_params)
         return EvosaxParams(

--- a/hydrax/algs/evosax.py
+++ b/hydrax/algs/evosax.py
@@ -86,9 +86,11 @@ class Evosax(SamplingBasedController):
             es_params = self.strategy.default_params
         self.es_params = es_params
 
-    def init_params(self, seed: int = 0) -> EvosaxParams:
+    def init_params(
+        self, initial_control: jax.Array = None, seed: int = 0
+    ) -> EvosaxParams:
         """Initialize the policy parameters."""
-        _params = super().init_params(seed)
+        _params = super().init_params(initial_control, seed)
         rng, init_rng = jax.random.split(_params.rng)
         opt_state = self.strategy.initialize(init_rng, self.es_params)
         return EvosaxParams(

--- a/hydrax/algs/mppi.py
+++ b/hydrax/algs/mppi.py
@@ -74,9 +74,11 @@ class MPPI(SamplingBasedController):
         self.num_samples = num_samples
         self.temperature = temperature
 
-    def init_params(self, seed: int = 0) -> MPPIParams:
+    def init_params(
+        self, initial_control: jax.Array = None, seed: int = 0
+    ) -> MPPIParams:
         """Initialize the policy parameters."""
-        _params = super().init_params(seed)
+        _params = super().init_params(initial_control, seed)
         return MPPIParams(tk=_params.tk, mean=_params.mean, rng=_params.rng)
 
     def sample_knots(self, params: MPPIParams) -> Tuple[jax.Array, MPPIParams]:

--- a/hydrax/algs/mppi.py
+++ b/hydrax/algs/mppi.py
@@ -75,10 +75,10 @@ class MPPI(SamplingBasedController):
         self.temperature = temperature
 
     def init_params(
-        self, initial_control: jax.Array = None, seed: int = 0
+        self, initial_knots: jax.Array = None, seed: int = 0
     ) -> MPPIParams:
         """Initialize the policy parameters."""
-        _params = super().init_params(initial_control, seed)
+        _params = super().init_params(initial_knots, seed)
         return MPPIParams(tk=_params.tk, mean=_params.mean, rng=_params.rng)
 
     def sample_knots(self, params: MPPIParams) -> Tuple[jax.Array, MPPIParams]:

--- a/hydrax/algs/predictive_sampling.py
+++ b/hydrax/algs/predictive_sampling.py
@@ -64,9 +64,11 @@ class PredictiveSampling(SamplingBasedController):
         self.noise_level = noise_level
         self.num_samples = num_samples
 
-    def init_params(self, seed: int = 0) -> PSParams:
+    def init_params(
+        self, initial_control: jax.Array = None, seed: int = 0
+    ) -> PSParams:
         """Initialize the policy parameters."""
-        _params = super().init_params(seed)
+        _params = super().init_params(initial_control, seed)
         return PSParams(tk=_params.tk, mean=_params.mean, rng=_params.rng)
 
     def sample_knots(self, params: PSParams) -> Tuple[jax.Array, PSParams]:

--- a/hydrax/algs/predictive_sampling.py
+++ b/hydrax/algs/predictive_sampling.py
@@ -65,10 +65,10 @@ class PredictiveSampling(SamplingBasedController):
         self.num_samples = num_samples
 
     def init_params(
-        self, initial_control: jax.Array = None, seed: int = 0
+        self, initial_knots: jax.Array = None, seed: int = 0
     ) -> PSParams:
         """Initialize the policy parameters."""
-        _params = super().init_params(initial_control, seed)
+        _params = super().init_params(initial_knots, seed)
         return PSParams(tk=_params.tk, mean=_params.mean, rng=_params.rng)
 
     def sample_knots(self, params: PSParams) -> Tuple[jax.Array, PSParams]:

--- a/hydrax/simulation/asynchronous.py
+++ b/hydrax/simulation/asynchronous.py
@@ -102,7 +102,7 @@ def run_controller(
     shm_data: SharedMemoryMujocoData,
     ready: Event,
     finished: Event,
-    initial_control: jax.Array = None,
+    initial_knots: jax.Array = None,
 ) -> None:
     """Run the controller, communicating with the simulator over shared memory.
 
@@ -111,11 +111,11 @@ def run_controller(
         shm_data: Shared memory object for state and control action data.
         ready: Shared flag for signaling that the controller is ready.
         finished: Shared flag for stopping the simulation.
-        initial_control: The initial control to use for the controller.
+        initial_knots: The initial control to use for the controller.
     """
     # Initialize the policy parameters and state estimate
     mjx_data = mjx.make_data(ctrl.task.model)
-    policy_params = ctrl.init_params(initial_control=initial_control)
+    policy_params = ctrl.init_params(initial_knots=initial_knots)
 
     # Print out some planning horizon information
     print(
@@ -224,7 +224,7 @@ def run_interactive(
     controller: SamplingBasedController,
     mj_model: mujoco.MjModel,
     mj_data: mujoco.MjData,
-    initial_control: jax.Array = None,
+    initial_knots: jax.Array = None,
 ) -> None:
     """Run an asynchronous interactive simulation.
 
@@ -236,7 +236,7 @@ def run_interactive(
         controller: The controller to use for planning.
         mj_model: Mujoco model for the simulation.
         mj_data: Mujoco data specifying the initial state.
-        initial_control: The initial control to use for the controller.
+        initial_knots: The initial knots of the control spline.
     """
     ctx = mp.get_context("spawn")  # Need to use spawn for jax compatibility
 
@@ -252,7 +252,7 @@ def run_interactive(
     )
     control = ctx.Process(
         target=run_controller,
-        args=(controller, shm_data, ready, finished, initial_control),
+        args=(controller, shm_data, ready, finished, initial_knots),
     )
 
     # Run the simulation and controller in parallel

--- a/hydrax/simulation/asynchronous.py
+++ b/hydrax/simulation/asynchronous.py
@@ -102,6 +102,7 @@ def run_controller(
     shm_data: SharedMemoryMujocoData,
     ready: Event,
     finished: Event,
+    initial_control: jax.Array = None,
 ) -> None:
     """Run the controller, communicating with the simulator over shared memory.
 
@@ -110,10 +111,11 @@ def run_controller(
         shm_data: Shared memory object for state and control action data.
         ready: Shared flag for signaling that the controller is ready.
         finished: Shared flag for stopping the simulation.
+        initial_control: The initial control to use for the controller.
     """
     # Initialize the policy parameters and state estimate
     mjx_data = mjx.make_data(ctrl.task.model)
-    policy_params = ctrl.init_params()
+    policy_params = ctrl.init_params(initial_control=initial_control)
 
     # Print out some planning horizon information
     print(
@@ -222,6 +224,7 @@ def run_interactive(
     controller: SamplingBasedController,
     mj_model: mujoco.MjModel,
     mj_data: mujoco.MjData,
+    initial_control: jax.Array = None,
 ) -> None:
     """Run an asynchronous interactive simulation.
 
@@ -233,6 +236,7 @@ def run_interactive(
         controller: The controller to use for planning.
         mj_model: Mujoco model for the simulation.
         mj_data: Mujoco data specifying the initial state.
+        initial_control: The initial control to use for the controller.
     """
     ctx = mp.get_context("spawn")  # Need to use spawn for jax compatibility
 
@@ -247,7 +251,8 @@ def run_interactive(
         args=(mj_model, mj_data, shm_data, ready, finished),
     )
     control = ctx.Process(
-        target=run_controller, args=(controller, shm_data, ready, finished)
+        target=run_controller,
+        args=(controller, shm_data, ready, finished, initial_control),
     )
 
     # Run the simulation and controller in parallel

--- a/hydrax/simulation/asynchronous.py
+++ b/hydrax/simulation/asynchronous.py
@@ -236,7 +236,7 @@ def run_interactive(
         controller: The controller to use for planning.
         mj_model: Mujoco model for the simulation.
         mj_data: Mujoco data specifying the initial state.
-        initial_knots: The initial knots of the control spline.
+        initial_knots: The initial knot points for the control spline at t=0
     """
     ctx = mp.get_context("spawn")  # Need to use spawn for jax compatibility
 

--- a/hydrax/simulation/deterministic.py
+++ b/hydrax/simulation/deterministic.py
@@ -24,6 +24,7 @@ def run_interactive(  # noqa: PLR0912, PLR0915
     mj_model: mujoco.MjModel,
     mj_data: mujoco.MjData,
     frequency: float,
+    initial_control: jax.Array = None,
     fixed_camera_id: int = None,
     show_traces: bool = True,
     max_traces: int = 5,
@@ -82,7 +83,7 @@ def run_interactive(  # noqa: PLR0912, PLR0915
     mjx_data = mjx_data.replace(
         mocap_pos=mj_data.mocap_pos, mocap_quat=mj_data.mocap_quat
     )
-    policy_params = controller.init_params()
+    policy_params = controller.init_params(initial_control=initial_control)
     jit_optimize = jax.jit(controller.optimize)
     jit_interp_func = jax.jit(controller.interp_func)
 

--- a/hydrax/simulation/deterministic.py
+++ b/hydrax/simulation/deterministic.py
@@ -51,7 +51,7 @@ def run_interactive(  # noqa: PLR0912, PLR0915
                   be slightly different from the model used by the controller.
         mj_data: A MuJoCo data object containing the initial system state.
         frequency: The requested control frequency (Hz) for replanning.
-        initial_knots: The initial knots of the control spline.
+        initial_knots: The initial knot points for the control spline at t=0
         fixed_camera_id: The camera ID to use for the fixed camera view.
         show_traces: Whether to show traces for the site positions.
         max_traces: The maximum number of traces to show at once.

--- a/hydrax/simulation/deterministic.py
+++ b/hydrax/simulation/deterministic.py
@@ -24,7 +24,7 @@ def run_interactive(  # noqa: PLR0912, PLR0915
     mj_model: mujoco.MjModel,
     mj_data: mujoco.MjData,
     frequency: float,
-    initial_control: jax.Array = None,
+    initial_knots: jax.Array = None,
     fixed_camera_id: int = None,
     show_traces: bool = True,
     max_traces: int = 5,
@@ -51,6 +51,7 @@ def run_interactive(  # noqa: PLR0912, PLR0915
                   be slightly different from the model used by the controller.
         mj_data: A MuJoCo data object containing the initial system state.
         frequency: The requested control frequency (Hz) for replanning.
+        initial_knots: The initial knots of the control spline.
         fixed_camera_id: The camera ID to use for the fixed camera view.
         show_traces: Whether to show traces for the site positions.
         max_traces: The maximum number of traces to show at once.
@@ -83,7 +84,7 @@ def run_interactive(  # noqa: PLR0912, PLR0915
     mjx_data = mjx_data.replace(
         mocap_pos=mj_data.mocap_pos, mocap_quat=mj_data.mocap_quat
     )
-    policy_params = controller.init_params(initial_control=initial_control)
+    policy_params = controller.init_params(initial_knots=initial_knots)
     jit_optimize = jax.jit(controller.optimize)
     jit_interp_func = jax.jit(controller.interp_func)
 

--- a/tests/test_alg_base.py
+++ b/tests/test_alg_base.py
@@ -1,6 +1,8 @@
 import jax.numpy as jnp
 
 from hydrax.alg_base import Trajectory
+from hydrax.tasks.particle import Particle
+from hydrax.algs.cem import CEM
 
 
 def test_traj() -> None:
@@ -13,6 +15,30 @@ def test_traj() -> None:
 
     traj = Trajectory(controls=U, knots=K, costs=J, trace_sites=P)
     assert len(traj) == horizon
+
+
+def test_init_params() -> None:
+    """Make sure we can initialize the policy parameters."""
+    task = Particle()
+    controller = CEM(
+        task, num_samples=10, num_elites=5, sigma_start=1.0, sigma_min=0.1
+    )
+    params = controller.init_params()
+    assert params.mean.shape == (task.model.nu * controller.num_knots,)
+    assert params.cov.shape == (task.model.nu * controller.num_knots,)
+    assert params.rng.shape == ()
+    assert params.tk.shape == (controller.num_knots,)
+
+    # Test with initial control
+    initial_control = jnp.rand((task.model.nu * controller.num_knots,))
+    params = controller.init_params(
+        initial_control=jnp.ones((task.model.nu * controller.num_knots,))
+    )
+    assert params.mean.shape == (task.model.nu * controller.num_knots,)
+    assert params.cov.shape == (task.model.nu * controller.num_knots,)
+    assert params.rng.shape == ()
+    assert params.tk.shape == (controller.num_knots,)
+    assert jnp.all(params.mean == initial_control)
 
 
 if __name__ == "__main__":

--- a/tests/test_alg_base.py
+++ b/tests/test_alg_base.py
@@ -30,15 +30,15 @@ def test_init_params() -> None:
     assert params.tk.shape == (controller.num_knots,)
 
     # Test with initial control
-    initial_control = jnp.rand((task.model.nu * controller.num_knots,))
+    initial_knots = jnp.rand((task.model.nu * controller.num_knots,))
     params = controller.init_params(
-        initial_control=jnp.ones((task.model.nu * controller.num_knots,))
+        initial_knots=jnp.ones((task.model.nu * controller.num_knots,))
     )
     assert params.mean.shape == (task.model.nu * controller.num_knots,)
     assert params.cov.shape == (task.model.nu * controller.num_knots,)
     assert params.rng.shape == ()
     assert params.tk.shape == (controller.num_knots,)
-    assert jnp.all(params.mean == initial_control)
+    assert jnp.all(params.mean == initial_knots)
 
 
 if __name__ == "__main__":

--- a/tests/test_alg_base.py
+++ b/tests/test_alg_base.py
@@ -1,5 +1,5 @@
 import jax.numpy as jnp
-from jax import random
+import jax
 
 from hydrax.alg_base import Trajectory
 from hydrax.tasks.particle import Particle
@@ -35,8 +35,8 @@ def test_init_params() -> None:
     assert params.tk.shape == (controller.num_knots,)
 
     # Test with initial control knots
-    key = random.PRNGKey(0)  # seed
-    initial_knots = random.uniform(
+    key = jax.random.key(0)  # seed
+    initial_knots = jax.random.uniform(
         key, shape=(controller.num_knots, task.model.nu)
     )
     params = controller.init_params(initial_knots=initial_knots)

--- a/tests/test_alg_base.py
+++ b/tests/test_alg_base.py
@@ -1,4 +1,5 @@
 import jax.numpy as jnp
+from jax import random
 
 from hydrax.alg_base import Trajectory
 from hydrax.tasks.particle import Particle
@@ -24,18 +25,23 @@ def test_init_params() -> None:
         task, num_samples=10, num_elites=5, sigma_start=1.0, sigma_min=0.1
     )
     params = controller.init_params()
-    assert params.mean.shape == (task.model.nu * controller.num_knots,)
-    assert params.cov.shape == (task.model.nu * controller.num_knots,)
+    expected_shape = (
+        controller.num_knots,
+        task.model.nu,
+    )
+    assert params.mean.shape == expected_shape
+    assert params.cov.shape == expected_shape
     assert params.rng.shape == ()
     assert params.tk.shape == (controller.num_knots,)
 
-    # Test with initial control
-    initial_knots = jnp.rand((task.model.nu * controller.num_knots,))
-    params = controller.init_params(
-        initial_knots=jnp.ones((task.model.nu * controller.num_knots,))
+    # Test with initial control knots
+    key = random.PRNGKey(0)  # seed
+    initial_knots = random.uniform(
+        key, shape=(controller.num_knots, task.model.nu)
     )
-    assert params.mean.shape == (task.model.nu * controller.num_knots,)
-    assert params.cov.shape == (task.model.nu * controller.num_knots,)
+    params = controller.init_params(initial_knots=initial_knots)
+    assert params.mean.shape == expected_shape
+    assert params.cov.shape == expected_shape
     assert params.rng.shape == ()
     assert params.tk.shape == (controller.num_knots,)
     assert jnp.all(params.mean == initial_knots)
@@ -43,3 +49,4 @@ def test_init_params() -> None:
 
 if __name__ == "__main__":
     test_traj()
+    test_init_params()


### PR DESCRIPTION
This PR adds the ability to set the initial mean (knots of the control spline) of the policy params. 

It is sometimes useful to be able to specify the initial mean, for instance, when the control actions are joint position references and the desired initial joint configuration is non-zero. 

