### PR TITLE
Improve humanoid mocap task tracking performance

### DIFF
--- a/examples/humanoid_mocap.py
+++ b/examples/humanoid_mocap.py
@@ -1,6 +1,7 @@
 import argparse
 
 import mujoco
+import jax.numpy as jnp
 
 from hydrax.algs import CEM
 from hydrax.simulation.deterministic import run_interactive
@@ -54,6 +55,10 @@ mj_model.opt.enableflags = mujoco.mjtEnableBit.mjENBL_OVERRIDE
 # Set the initial state
 mj_data = mujoco.MjData(mj_model)
 mj_data.qpos[:] = task.reference[0]
+initial_knots = jnp.tile(
+    task.reference[0][7:],
+    (ctrl.num_knots, 1),
+)
 
 if args.show_reference:
     reference = task.reference
@@ -68,4 +73,6 @@ run_interactive(
     show_traces=False,
     reference=reference,
     reference_fps=task.reference_fps,
+    record_video=True,
+    initial_knots=initial_knots,
 )

--- a/examples/humanoid_mocap.py
+++ b/examples/humanoid_mocap.py
@@ -1,7 +1,6 @@
 import argparse
 
 import mujoco
-import jax.numpy as jnp
 
 from hydrax.algs import CEM
 from hydrax.simulation.deterministic import run_interactive

--- a/examples/humanoid_mocap.py
+++ b/examples/humanoid_mocap.py
@@ -81,6 +81,5 @@ run_interactive(
     show_traces=False,
     reference=reference,
     reference_fps=task.reference_fps,
-    record_video=True,
     initial_knots=initial_knots,
 )

--- a/examples/humanoid_mocap.py
+++ b/examples/humanoid_mocap.py
@@ -63,10 +63,7 @@ mj_model.opt.enableflags = mujoco.mjtEnableBit.mjENBL_OVERRIDE
 # Set the initial state
 mj_data = mujoco.MjData(mj_model)
 mj_data.qpos[:] = task.reference[0]
-initial_knots = jnp.tile(
-    task.reference[0][7:],
-    (ctrl.num_knots, 1),
-)
+initial_knots = task.reference[: ctrl.num_knots, 7:]
 
 if args.show_reference:
     reference = task.reference

--- a/examples/humanoid_mocap.py
+++ b/examples/humanoid_mocap.py
@@ -26,6 +26,13 @@ parser.add_argument(
     action="store_true",
     help="Show the reference trajectory as a 'ghost' in the simulation.",
 )
+parser.add_argument(
+    "--iterations",
+    type=int,
+    default=1,
+    help="Number of CEM iterations.",
+)
+
 args = parser.parse_args()
 
 # Define the task (cost and dynamics)
@@ -42,6 +49,7 @@ ctrl = CEM(
     plan_horizon=0.6,
     spline_type="zero",
     num_knots=4,
+    iterations=args.iterations,
 )
 
 # Define the model used for simulation

--- a/hydrax/models/g1/g1_23dof.xml
+++ b/hydrax/models/g1/g1_23dof.xml
@@ -303,7 +303,7 @@
     <position class="g1" name="right_shoulder_yaw_joint" joint="right_shoulder_yaw_joint" />
     <position class="g1" name="right_elbow_joint" joint="right_elbow_joint" />
     <position class="g1" name="right_wrist_roll_joint" joint="right_wrist_roll_joint" />
-    </actuator>
+  </actuator>
 
   <sensor>
     <gyro site="imu_in_torso" name="imu-torso-angular-velocity" cutoff="34.9" noise="0.0005" />
@@ -312,5 +312,10 @@
     <framelinvel name="imu_in_torso_linvel" objtype="site" objname="imu_in_torso" />
     <gyro site="imu_in_pelvis" name="imu-pelvis-angular-velocity" cutoff="34.9" noise="0.0005" />
     <accelerometer site="imu_in_pelvis" name="imu-pelvis-linear-acceleration" cutoff="157" noise="0.01" />
+    
+    <framepos name="left_foot_position" objtype="site" objname="left_foot" />
+    <framequat name="left_foot_orientation" objtype="site" objname="left_foot" />
+    <framepos name="right_foot_position" objtype="site" objname="right_foot" />
+    <framequat name="right_foot_orientation" objtype="site" objname="right_foot" />
   </sensor>
 </mujoco>

--- a/hydrax/tasks/humanoid_mocap.py
+++ b/hydrax/tasks/humanoid_mocap.py
@@ -6,6 +6,7 @@ import mujoco
 import numpy as np
 from huggingface_hub import hf_hub_download
 from mujoco import mjx
+from mujoco.mjx._src.math import quat_sub
 
 from hydrax import ROOT
 from hydrax.task_base import Task
@@ -35,7 +36,21 @@ class HumanoidMocap(Task):
             trace_sites=["imu_in_torso", "left_foot", "right_foot"],
         )
 
-        # Download the retargeted mocap reference
+        # Get sensor IDs
+        self.left_foot_pos_sensor = mujoco.mj_name2id(
+            mj_model, mujoco.mjtObj.mjOBJ_SENSOR, "left_foot_position"
+        )
+        self.left_foot_quat_sensor = mujoco.mj_name2id(
+            mj_model, mujoco.mjtObj.mjOBJ_SENSOR, "left_foot_orientation"
+        )
+        self.right_foot_pos_sensor = mujoco.mj_name2id(
+            mj_model, mujoco.mjtObj.mjOBJ_SENSOR, "right_foot_position"
+        )
+        self.right_foot_quat_sensor = mujoco.mj_name2id(
+            mj_model, mujoco.mjtObj.mjOBJ_SENSOR, "right_foot_orientation"
+        )
+
+        # Download and load reference data
         npz_file = np.load(
             hf_hub_download(
                 repo_id="robfiras/loco-mujoco-datasets",
@@ -48,6 +63,33 @@ class HumanoidMocap(Task):
         self.reference = jnp.array(reference)
         self.reference_fps = npz_file["frequency"]
 
+        # Precompute reference foot positions and orientations
+        mj_data = mujoco.MjData(mj_model)
+        n_frames = len(reference)
+        ref_left_pos = np.zeros((n_frames, 3))
+        ref_left_quat = np.zeros((n_frames, 4))
+        ref_right_pos = np.zeros((n_frames, 3))
+        ref_right_quat = np.zeros((n_frames, 4))
+        for i in range(n_frames):
+            mj_data.qpos[:] = reference[i]
+            mujoco.mj_forward(mj_model, mj_data)
+            ref_left_pos[i] = mj_data.site_xpos[mj_model.site("left_foot").id]
+            ref_right_pos[i] = mj_data.site_xpos[mj_model.site("right_foot").id]
+            mujoco.mju_mat2Quat(
+                ref_left_quat[i],
+                mj_data.site_xmat[mj_model.site("left_foot").id].flatten(),
+            )
+            mujoco.mju_mat2Quat(
+                ref_right_quat[i],
+                mj_data.site_xmat[mj_model.site("right_foot").id].flatten(),
+            )
+
+        # Convert reference data to jax arrays
+        self.ref_left_pos = jnp.array(ref_left_pos)
+        self.ref_left_quat = jnp.array(ref_left_quat)
+        self.ref_right_pos = jnp.array(ref_right_pos)
+        self.ref_right_quat = jnp.array(ref_right_quat)
+
         # Cost weights
         cost_weights = np.ones(mj_model.nq)
         cost_weights[:7] = 5.0  # Base pose is more important
@@ -59,6 +101,56 @@ class HumanoidMocap(Task):
         i = jnp.clip(i, 0, self.reference.shape[0] - 1)
         return self.reference[i, :]
 
+    def _get_reference_foot_data(self, t: jax.Array) -> tuple[jax.Array, ...]:
+        """Get the reference foot positions and orientations at time t."""
+        i = jnp.int32(t * self.reference_fps)
+        i = jnp.clip(i, 0, self.reference.shape[0] - 1)
+        return (
+            self.ref_left_pos[i],
+            self.ref_left_quat[i],
+            self.ref_right_pos[i],
+            self.ref_right_quat[i],
+        )
+
+    def _get_foot_position_errors(
+        self, state: mjx.Data
+    ) -> tuple[jax.Array, jax.Array]:
+        """Get position errors for both feet."""
+        ref_left_pos, _, ref_right_pos, _ = self._get_reference_foot_data(
+            state.time
+        )
+
+        left_pos_adr = self.model.sensor_adr[self.left_foot_pos_sensor]
+        right_pos_adr = self.model.sensor_adr[self.right_foot_pos_sensor]
+
+        left_err = (
+            state.sensordata[left_pos_adr : left_pos_adr + 3] - ref_left_pos
+        )
+        right_err = (
+            state.sensordata[right_pos_adr : right_pos_adr + 3] - ref_right_pos
+        )
+
+        return left_err, right_err
+
+    def _get_foot_orientation_errors(
+        self, state: mjx.Data
+    ) -> tuple[jax.Array, jax.Array]:
+        """Get orientation errors for both feet."""
+        _, ref_left_quat, _, ref_right_quat = self._get_reference_foot_data(
+            state.time
+        )
+
+        left_quat_adr = self.model.sensor_adr[self.left_foot_quat_sensor]
+        right_quat_adr = self.model.sensor_adr[self.right_foot_quat_sensor]
+
+        left_quat = state.sensordata[left_quat_adr : left_quat_adr + 4]
+        right_quat = state.sensordata[right_quat_adr : right_quat_adr + 4]
+
+        left_err = quat_sub(left_quat, ref_left_quat)
+        right_err = quat_sub(right_quat, ref_right_quat)
+
+        return left_err, right_err
+
     def running_cost(self, state: mjx.Data, control: jax.Array) -> jax.Array:
         """The running cost ℓ(xₜ, uₜ)."""
         # Configuration error weighs the base pose more heavily
@@ -67,21 +159,51 @@ class HumanoidMocap(Task):
         q_err = self.cost_weights * (q - q_ref)
         configuration_cost = jnp.sum(jnp.square(q_err))
 
-        # Control penalty incentivizes driving toward the reference, since all
-        # joints are position-controlled
+        # Foot tracking costs
+        left_pos_err, right_pos_err = self._get_foot_position_errors(state)
+        left_ori_err, right_ori_err = self._get_foot_orientation_errors(state)
+
+        foot_position_cost = jnp.sum(jnp.square(left_pos_err)) + jnp.sum(
+            jnp.square(right_pos_err)
+        )
+        foot_orientation_cost = jnp.sum(jnp.square(left_ori_err)) + jnp.sum(
+            jnp.square(right_ori_err)
+        )
+
+        # Control penalty
         u_ref = q_ref[7:]
         control_cost = jnp.sum(jnp.square(control - u_ref))
 
-        return 1.0 * configuration_cost + 1.0 * control_cost
+        return (
+            1.0 * configuration_cost
+            + 5.0 * foot_position_cost
+            + 0.1 * foot_orientation_cost
+            + 1.0 * control_cost
+        )
 
     def terminal_cost(self, state: mjx.Data) -> jax.Array:
         """The terminal cost ϕ(x_T)."""
         q_ref = self._get_reference_configuration(state.time)
         q = state.qpos
         q_err = self.cost_weights * (q - q_ref)
-        # N.B. we multiply by dt to ensure the terminal cost is comparable to
-        # the running cost, since this isn't a proper cost-to-go.
-        return self.dt * jnp.sum(jnp.square(q_err))
+        configuration_cost = jnp.sum(jnp.square(q_err))
+
+        # Add foot tracking costs to terminal cost
+        left_pos_err, right_pos_err = self._get_foot_position_errors(state)
+        left_ori_err, right_ori_err = self._get_foot_orientation_errors(state)
+
+        foot_position_cost = jnp.sum(jnp.square(left_pos_err)) + jnp.sum(
+            jnp.square(right_pos_err)
+        )
+        foot_orientation_cost = jnp.sum(jnp.square(left_ori_err)) + jnp.sum(
+            jnp.square(right_ori_err)
+        )
+
+        return self.dt * (
+            1.0 * configuration_cost
+            + 1.0 * foot_position_cost
+            + 0.1 * foot_orientation_cost
+        )
 
     def domain_randomize_model(self, rng: jax.Array) -> Dict[str, jax.Array]:
         """Randomize the friction parameters."""


### PR DESCRIPTION
This PR makes the following changes to the `humanoid_mocap.py` task:

- Sets the initial knots of the control spline to match first joint configuration reference from the data (avoids initial overshoot behavior)

- Adds a feet site tracking term to cost function with aim to help prevent foot scuffing 

- There is a notable performance improvement with increase in CEM `iterations`, at the cost of runtime performance, so I added an `iterations` argument to the example


I used the default walk dataset to compare the following.

### Walk task (no foot tracking cost, 1 iteration)
Poor tracking performance

https://github.com/user-attachments/assets/3fd3e64e-a09c-424c-8ac0-b3d96d235a95

### Walk task (foot tracking cost, 1 iteration)
Considerably better tracking performance

https://github.com/user-attachments/assets/5c76a5f4-42cf-4b47-a237-70cadce78368



### Walk task (foot tracking cost, 5 iterations)
Much better tracking performance!

https://github.com/user-attachments/assets/4fd02f32-286a-441e-8f7c-e87ded50a15b


