### PR TITLE
fix get_action in alg_base.py

### DIFF
--- a/hydrax/alg_base.py
+++ b/hydrax/alg_base.py
@@ -332,5 +332,5 @@ class SamplingBasedController(ABC):
         """
         knots = params.mean[None, ...]  # (1, num_knots, nu)
         tk = params.tk
-        u = self.interp_func(t, tk, knots)[0, 0]  # (nu,)
+        u = self.interp_func(t, tk, knots)[0]  # (nu,)
         return u

--- a/tests/test_alg_base.py
+++ b/tests/test_alg_base.py
@@ -46,7 +46,18 @@ def test_init_params() -> None:
     assert params.tk.shape == (controller.num_knots,)
     assert jnp.all(params.mean == initial_knots)
 
+def test_get_action() -> None:
+    """Make sure we can get the action from the policy parameters of the correct shape."""
+    task = Particle()
+    controller = CEM(
+        task, num_samples=10, num_elites=5, sigma_start=1.0, sigma_min=0.1
+    )
+    params = controller.init_params()
+    action = controller.get_action(params, 0)
+    expected_shape = task.model.nu
+    assert action.shape[0] == expected_shape
 
 if __name__ == "__main__":
     test_traj()
     test_init_params()
+    test_get_action()


### PR DESCRIPTION
the current get_action in alg_base.py returns the first element of the first action vector as it indexes [0,0]. Updated it to return the first action vector.