### PR TITLE
Update evosax to 0.2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 # TODO: evosax v0.2.0 introduced many breaking changes in the API that cause test failures
 dependencies = [
-    "evosax<0.2.0",
+    "evosax>=0.2.0",
     "flax>=0.10.0",
     "huggingface_hub>=0.29.3",
     "interpax>=0.3.7",

--- a/tests/test_cma_es.py
+++ b/tests/test_cma_es.py
@@ -1,4 +1,4 @@
-import evosax
+from evosax.algorithms.distribution_based.cma_es import CMA_ES
 import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
@@ -13,7 +13,7 @@ def test_cmaes() -> None:
     task = Pendulum()
     ctrl = Evosax(
         task,
-        evosax.CMA_ES,
+        CMA_ES,
         num_samples=32,
         plan_horizon=1.0,
         spline_type="zero",
@@ -23,7 +23,7 @@ def test_cmaes() -> None:
     # Initialize the policy parameters
     params = ctrl.init_params()
     assert params.opt_state.C.shape == (ctrl.num_knots, ctrl.num_knots)
-    assert params.opt_state.weights.shape == (32,)
+    assert ctrl.es_params.weights.shape == (32,) # weights in evosax 0.2.0 stay in params
 
     # Sample control sequences from the policy
     knots, params = ctrl.sample_knots(params)
@@ -51,13 +51,16 @@ def test_open_loop() -> None:
     task = Pendulum()
     opt = Evosax(
         task,
-        evosax.CMA_ES,
+        CMA_ES,
         num_samples=32,
-        elite_ratio=0.1,
         plan_horizon=1.0,
         spline_type="zero",
         num_knots=11,
     )
+
+    # elite_ratio was not an argument of the constructor in exosax 0.2.0, it was hard-coded
+    opt.elite_ratio = 0.1
+
     jit_opt = jax.jit(opt.optimize)
 
     # Initialize the system state and policy parameters


### PR DESCRIPTION
- Bump dependency to evosax>=0.2.0 in pyproject.toml.

- Adapt Evosax controller to new API (population_size, solution, new init/tell signatures, renamed fields).

- Update imports (CMA_ES path) and test assertions.

- Keeps public Hydrax API unchanged; all tests pass on 0.2.0.