### PR TITLE
Add Model Tensor Planning (MTP) algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Available methods:
 | [DIAL-MPC](https://arxiv.org/abs/2409.15610) | MPPI with dual-loop, annealed sampling covariance. | [`hydrax.algs.DIAL`](hydrax/algs/dial.py) |
 | [Evosax](https://github.com/RobertTLange/evosax/) | Any of the 30+ evolution strategies implemented in `evosax`. Includes CMA-ES, differential evolution, and many more. | [`hydrax.algs.Evosax`](hydrax/algs.evosax.py) |
 | [MPPI-CMA](https://arxiv.org/pdf/2506.22087) | MPPI with an adaptive sampling distribution. | [`hydrax.algs.MppiCma`](hydrax/algs/mppi_cma.py) |
+| [MTP](https://arxiv.org/abs/2505.01059) | Mix structured tensor-sampled trajectories with a local CEM update for global exploration. | [`hydrax.algs.MTP`](hydrax/algs/mtp.py) |
 
 ## News
 

--- a/examples/navigation.py
+++ b/examples/navigation.py
@@ -1,0 +1,108 @@
+import argparse
+
+import mujoco
+
+from hydrax.algs import CEM, MPPI, MTP, PredictiveSampling
+from hydrax.simulation.deterministic import run_interactive
+from hydrax.tasks.navigation import Navigation
+
+"""
+Run an interactive simulation of the U-maze navigation task.
+
+Double click on the green target, then drag it around with [ctrl + right-click].
+The starting pointmass is placed inside a U-shaped barrier so that local
+samplers (PS / MPPI / CEM) tend to stall against the inner wall, whereas
+MTP's tensor sampler routes around it.
+"""
+
+parser = argparse.ArgumentParser(
+    description="Run an interactive simulation of the navigation task."
+)
+parser.add_argument(
+    "--warp",
+    action="store_true",
+    help="Whether to use the (experimental) MjWarp backend. (default: False)",
+    required=False,
+)
+subparsers = parser.add_subparsers(
+    dest="algorithm", help="Sampling algorithm (choose one)"
+)
+subparsers.add_parser("ps", help="Predictive Sampling")
+subparsers.add_parser("mppi", help="Model Predictive Path Integral Control")
+subparsers.add_parser("cem", help="Cross-Entropy Method")
+subparsers.add_parser("mtp", help="Model Tensor Planning")
+args = parser.parse_args()
+
+task = Navigation(impl="warp" if args.warp else "jax")
+
+if args.algorithm == "ps" or args.algorithm is None:
+    print("Running predictive sampling")
+    ctrl = PredictiveSampling(
+        task,
+        num_samples=32,
+        noise_level=0.3,
+        plan_horizon=0.5,
+        spline_type="zero",
+        num_knots=11,
+    )
+
+elif args.algorithm == "mppi":
+    print("Running MPPI")
+    ctrl = MPPI(
+        task,
+        num_samples=32,
+        noise_level=0.3,
+        temperature=0.01,
+        plan_horizon=0.5,
+        spline_type="zero",
+        num_knots=11,
+    )
+
+elif args.algorithm == "cem":
+    print("Running CEM")
+    ctrl = CEM(
+        task,
+        num_samples=64,
+        num_elites=8,
+        sigma_start=0.5,
+        sigma_min=0.05,
+        explore_fraction=0.3,
+        plan_horizon=0.5,
+        spline_type="zero",
+        num_knots=11,
+    )
+
+elif args.algorithm == "mtp":
+    print("Running MTP")
+    ctrl = MTP(
+        task,
+        num_samples=64,
+        m_pts=3,
+        n_per_layer=50,
+        num_elites=8,
+        sigma_start=0.5,
+        sigma_min=0.05,
+        sigma_max=1.0,
+        beta=0.5,
+        alpha=0.5,
+        mtp_interpolation="akima",
+        plan_horizon=0.5,
+        spline_type="zero",
+        num_knots=11,
+    )
+else:
+    parser.error("Invalid algorithm")
+
+mj_model = task.mj_model
+mj_data = mujoco.MjData(mj_model)
+mj_data.qpos[:2] = [-0.2, 0.0]
+mj_data.mocap_pos[0] = [0.25, 0.0, 0.01]
+
+run_interactive(
+    ctrl,
+    mj_model,
+    mj_data,
+    frequency=50,
+    show_traces=True,
+    max_traces=5,
+)

--- a/hydrax/algs/__init__.py
+++ b/hydrax/algs/__init__.py
@@ -3,6 +3,15 @@ from .dial import DIAL
 from .evosax import Evosax
 from .mppi import MPPI
 from .mppi_cma import MppiCma
+from .mtp import MTP
 from .predictive_sampling import PredictiveSampling
 
-__all__ = ["CEM", "MPPI", "PredictiveSampling", "Evosax", "DIAL", "MppiCma"]
+__all__ = [
+    "CEM",
+    "MPPI",
+    "MTP",
+    "PredictiveSampling",
+    "Evosax",
+    "DIAL",
+    "MppiCma",
+]

--- a/hydrax/algs/mtp.py
+++ b/hydrax/algs/mtp.py
@@ -1,0 +1,318 @@
+"""Model Tensor Planning (MTP) controller.
+
+Implements the sampling-based MPC framework of Le et al. 2026
+(arxiv 2505.01059), which generates globally-diverse trajectory
+candidates via structured tensor sampling over a randomised M-partite
+graph and mixes them with a local CEM-style distribution.
+"""
+
+from typing import Literal, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+from flax.struct import dataclass
+
+from hydrax.alg_base import SamplingBasedController, SamplingParams, Trajectory
+from hydrax.risk import RiskStrategy
+from hydrax.task_base import Task
+from hydrax.utils.spline import (
+    compute_b_spline_matrix,
+    poly_akima,
+    poly_interpolation,
+)
+
+MTPInterpolationType = Literal["akima", "bspline", "linear"]
+
+
+@dataclass
+class MTPParams(SamplingParams):
+    """Policy parameters for Model Tensor Planning.
+
+    Attributes:
+        tk: The knot times of the control spline.
+        mean: Mean of the local CEM knot distribution, μ = [u₀, ...].
+        rng: The pseudo-random number generator key.
+        cov: Diagonal standard deviation of the local CEM distribution.
+        best_knots: Best spline knots from the previous optimisation step.
+    """
+
+    cov: jax.Array
+    best_knots: jax.Array
+
+
+class MTP(SamplingBasedController):
+    """Model Tensor Planning sampling-based MPC.
+
+    MTP draws a fraction ``beta`` of the rollouts from a structured
+    M-partite tensor sampler (random paths through ``M`` waypoints with
+    ``N`` candidates each, smoothed by an Akima/B-spline/linear
+    interpolation) and the remaining rollouts from a local Gaussian
+    around the current mean. Elite rollouts update the local mean and
+    covariance with a CEM-style softmax weighting.
+    """
+
+    def __init__(
+        self,
+        task: Task,
+        num_samples: int,
+        m_pts: int = 3,
+        n_per_layer: int = 50,
+        degree: int = 2,
+        num_elites: int = 5,
+        sigma_start: float = 0.5,
+        sigma_min: float = 0.1,
+        sigma_max: float = 1.0,
+        temperature: float = 0.1,
+        beta: float = 0.1,
+        alpha: float = 0.5,
+        mtp_interpolation: MTPInterpolationType = "akima",
+        num_randomizations: int = 1,
+        risk_strategy: Optional[RiskStrategy] = None,
+        seed: int = 0,
+        plan_horizon: float = 1.0,
+        spline_type: Literal["zero", "linear", "cubic"] = "zero",
+        num_knots: int = 4,
+        iterations: int = 1,
+    ) -> None:
+        """Initialise the controller.
+
+        Args:
+            task: The dynamics and cost for the system we want to control.
+            num_samples: Total number of control sequences to evaluate per
+                iteration. Must be at least ``num_elites + 1`` (one slot is
+                always reserved for the previous best).
+            m_pts: Number of tensor waypoints (graph depth).
+            n_per_layer: Number of candidate values per waypoint
+                (graph width).
+            degree: B-spline degree, only consulted when
+                ``mtp_interpolation='bspline'``. Must be ``>= 2``.
+            num_elites: Number of elite rollouts kept per iteration.
+            sigma_start: Initial standard deviation of the local Gaussian.
+            sigma_min: Lower clip on the local standard deviation.
+            sigma_max: Upper clip on the local standard deviation. Also
+                used to derive a finite sampling range when actuator
+                bounds are infinite.
+            temperature: Softmax temperature λ used for elite weighting.
+            beta: Fraction of rollouts drawn from the tensor sampler. The
+                remainder are drawn from the local Gaussian.
+            alpha: CEM smoothing weight. ``alpha = 0`` applies the new
+                statistics in full; ``alpha = 1`` keeps the old ones.
+            mtp_interpolation: Smoothing applied to each tensor path
+                before it is used as a control sequence.
+            num_randomizations: The number of domain randomizations to use.
+            risk_strategy: How to combining costs from different
+                randomizations. Defaults to average cost.
+            seed: The random seed for domain randomization.
+            plan_horizon: The time horizon for the rollout in seconds.
+            spline_type: The type of spline used for control interpolation.
+                Defaults to "zero" (zero-order hold).
+            num_knots: The number of knots in the control spline.
+            iterations: The number of optimization iterations to perform.
+        """
+        if degree < 2:
+            raise ValueError(f"degree must be at least 2, got {degree}.")
+        if num_elites < 1:
+            raise ValueError(
+                f"num_elites must be at least 1, got {num_elites}."
+            )
+        if num_elites >= num_samples:
+            raise ValueError(
+                f"num_elites ({num_elites}) must be strictly less than "
+                f"num_samples ({num_samples})."
+            )
+        if mtp_interpolation == "bspline" and m_pts < degree + 1:
+            raise ValueError(
+                f"B-spline interpolation requires m_pts >= degree + 1 "
+                f"(got m_pts={m_pts}, degree={degree}). With m_pts < "
+                f"degree+1 the valid B-spline parameter domain collapses "
+                f"to a point and the tensor branch produces flat samples. "
+                f"Use 'akima' or 'linear' for small m_pts, or increase "
+                f"m_pts."
+            )
+
+        super().__init__(
+            task,
+            num_randomizations=num_randomizations,
+            risk_strategy=risk_strategy,
+            seed=seed,
+            plan_horizon=plan_horizon,
+            spline_type=spline_type,
+            num_knots=num_knots,
+            iterations=iterations,
+        )
+
+        self.num_samples = num_samples
+        self.m_pts = m_pts
+        self.n_per_layer = n_per_layer
+        self.degree = degree
+        self.num_elites = num_elites
+        self.sigma_start = sigma_start
+        self.sigma_min = sigma_min
+        self.sigma_max = sigma_max
+        self.temperature = temperature
+        self.beta = beta
+        self.alpha = alpha
+        self.mtp_interpolation = mtp_interpolation
+
+        # Always reserve one slot for the previous best, then split the
+        # remainder between the tensor branch and the local Gaussian.
+        mtp_samples = int(round(num_samples * beta))
+        self.mtp_samples = min(max(mtp_samples, 0), num_samples - 1)
+        self.cem_samples = num_samples - self.mtp_samples - 1
+
+        # Pre-baked spline parameters. These are independent of the rng so
+        # they can be allocated once at init time and reused across every
+        # planning step.
+        self._aknots = jnp.linspace(1.0, m_pts, m_pts)
+        bknots = jnp.arange(m_pts + degree + 1)
+        self._bmat = compute_b_spline_matrix(bknots, degree, num_knots)
+
+        # Linear branch: pre-bake a (num_knots, m_pts) interpolation matrix
+        # so the branch becomes a single einsum, mirroring the bspline
+        # branch and avoiding any per-step searchsorted overhead.
+        if m_pts > 1:
+            n_total = -(-num_knots // (m_pts - 1)) * (m_pts - 1)  # ceil-div
+            t_lin = jnp.linspace(0.0, m_pts - 1, n_total + 1)[:-1]
+            i_idx = jnp.clip(jnp.floor(t_lin).astype(jnp.int32), 0, m_pts - 2)
+            s = t_lin - i_idx
+            cols = jnp.arange(m_pts)
+            self._linmat = jnp.where(
+                cols[None, :] == i_idx[:, None], 1.0 - s[:, None], 0.0
+            ) + jnp.where(cols[None, :] == i_idx[:, None] + 1, s[:, None], 0.0)
+        else:
+            self._linmat = jnp.ones((num_knots, 1))
+
+        # Number of evaluation points per Akima segment so the total knot
+        # count covers ``num_knots`` (we then slice off any overhang).
+        self._akima_pts_per_seg = (
+            -(-num_knots // (m_pts - 1)) if m_pts > 1 else num_knots
+        )
+
+    def init_params(
+        self, initial_knots: Optional[jax.Array] = None, seed: int = 0
+    ) -> MTPParams:
+        """Initialise the policy parameters."""
+        _params = super().init_params(initial_knots, seed)
+        cov = jnp.full_like(_params.mean, self.sigma_start)
+        best_knots = jnp.zeros_like(_params.mean)
+        return MTPParams(
+            tk=_params.tk,
+            mean=_params.mean,
+            rng=_params.rng,
+            cov=cov,
+            best_knots=best_knots,
+        )
+
+    def _interp_paths(self, paths: jax.Array) -> jax.Array:
+        """Smooth tensor paths into ``(B, num_knots, nu)`` knot tensors."""
+        if self.mtp_interpolation == "akima":
+            a = jax.vmap(poly_akima, in_axes=(None, 0))(self._aknots, paths)
+            return poly_interpolation(a, self._akima_pts_per_seg)[
+                :, : self.num_knots
+            ]
+        if self.mtp_interpolation == "bspline":
+            return jnp.einsum("bmd,hm->bhd", paths, self._bmat)
+        if self.mtp_interpolation == "linear":
+            return jnp.einsum("bmd,hm->bhd", paths, self._linmat)[
+                :, : self.num_knots
+            ]
+        raise ValueError(
+            f"Invalid MTP interpolation: {self.mtp_interpolation}. "
+            "Expected one of ['akima', 'bspline', 'linear']."
+        )
+
+    def sample_knots(self, params: MTPParams) -> Tuple[jax.Array, MTPParams]:
+        """Sample control spline knots using tensor + local Gaussian mixing.
+
+        Each call returns exactly ``num_samples`` knot sequences:
+        the previous-best slot, ``mtp_samples`` tensor-sampled
+        sequences, and ``cem_samples`` local Gaussian perturbations
+        of the current mean.
+        """
+        rng = params.rng
+        nu = self.task.model.nu
+        best = params.best_knots[None, ...]  # (1, num_knots, nu)
+
+        if self.mtp_samples >= 1:
+            rng, tensor_rng = jax.random.split(rng)
+
+            # Hydrax marks unbounded actuators with ±inf; substitute a
+            # finite range derived from the current mean ± k·sigma_max so
+            # ``jax.random.uniform`` never returns NaN.
+            k = 3.0
+            mean_lo = jnp.min(params.mean, axis=0) - k * self.sigma_max
+            mean_hi = jnp.max(params.mean, axis=0) + k * self.sigma_max
+            u_min = jnp.where(
+                jnp.isfinite(self.task.u_min), self.task.u_min, mean_lo
+            )
+            u_max = jnp.where(
+                jnp.isfinite(self.task.u_max), self.task.u_max, mean_hi
+            )
+
+            # Sample tensor paths directly. Mathematically identical to
+            # building a (m_pts, n_per_layer, nu) graph and gathering
+            # along independent layer indices, but skips the
+            # m_pts·n_per_layer·nu materialisation, one RNG split, and
+            # the gather op.
+            paths = jax.random.uniform(
+                tensor_rng,
+                (self.mtp_samples, self.m_pts, nu),
+                minval=u_min,
+                maxval=u_max,
+            )
+            mtp_knots = self._interp_paths(paths)
+            all_knots = jnp.concatenate([best, mtp_knots], axis=0)
+        else:
+            all_knots = best
+
+        if self.cem_samples > 0:
+            rng, sample_rng = jax.random.split(rng)
+            noise = jax.random.normal(
+                sample_rng, (self.cem_samples, self.num_knots, nu)
+            )
+            cem_knots = params.mean + params.cov * noise
+            all_knots = jnp.concatenate([all_knots, cem_knots], axis=0)
+
+        return all_knots, params.replace(rng=rng)
+
+    def update_params(
+        self, params: MTPParams, rollouts: Trajectory
+    ) -> MTPParams:
+        """Refit the local Gaussian with weighted elite statistics."""
+        costs = jnp.sum(rollouts.costs, axis=1)  # (num_samples,)
+
+        # Top-K elite selection in O(N + K log K).
+        _, elite_idx = jax.lax.top_k(-costs, self.num_elites)
+        elite_knots = rollouts.knots[elite_idx]
+        elite_costs = costs[elite_idx]
+
+        # Subtract the elite minimum to keep softmax exponents bounded.
+        # softmax is logsumexp-stable on its own, so no NaN guard is
+        # needed: any NaN in ``elite_costs`` means an upstream cost bug
+        # we want to surface, not silently hide.
+        baseline = jnp.min(elite_costs)
+        weights = jax.nn.softmax(
+            -(elite_costs - baseline) / self.temperature, axis=0
+        )
+
+        # Weighted mean and Bessel-corrected std (the (E-1)/E correction
+        # for uniform weights, generalised to weighted samples).
+        mean = jnp.sum(weights[:, None, None] * elite_knots, axis=0)
+        var = jnp.sum(
+            weights[:, None, None] * (elite_knots - mean) ** 2, axis=0
+        )
+        bessel = 1.0 / jnp.maximum(1.0 - jnp.sum(weights**2), 1e-6)
+        cov = jnp.sqrt(var * bessel)
+        cov = jnp.clip(cov, self.sigma_min, self.sigma_max)
+
+        # Momentum smoothing. Variance update is the standard CMA convex
+        # blend ``α·old + (1-α)·new`` (algebraically identical to the
+        # earlier ``new + α·(old-new)`` form but reads as the standard
+        # convention and saves one fused op).
+        mean = mean + self.alpha * (params.mean - mean)
+        new_var = cov**2
+        old_var = params.cov**2
+        cov = jnp.sqrt(self.alpha * old_var + (1.0 - self.alpha) * new_var)
+
+        best_knots = rollouts.knots[elite_idx[0]]
+        return params.replace(mean=mean, cov=cov, best_knots=best_knots)

--- a/hydrax/algs/mtp.py
+++ b/hydrax/algs/mtp.py
@@ -1,6 +1,6 @@
 """Model Tensor Planning (MTP) controller.
 
-Implements the sampling-based MPC framework of Le et al. 2026
+Implements the sampling-based MPC framework of Le et al. 2025
 (arxiv 2505.01059), which generates globally-diverse trajectory
 candidates via structured tensor sampling over a randomised M-partite
 graph and mixes them with a local CEM-style distribution.
@@ -11,6 +11,7 @@ from typing import Literal, Optional, Tuple
 import jax
 import jax.numpy as jnp
 from flax.struct import dataclass
+from mujoco import mjx
 
 from hydrax.alg_base import SamplingBasedController, SamplingParams, Trajectory
 from hydrax.risk import RiskStrategy
@@ -202,6 +203,21 @@ class MTP(SamplingBasedController):
             cov=cov,
             best_knots=best_knots,
         )
+
+    def optimize(
+        self, state: mjx.Data, params: MTPParams
+    ) -> Tuple[MTPParams, Trajectory]:
+        """Optimise, warm-starting both ``mean`` and ``best_knots``."""
+        tk = params.tk
+        new_tk = (
+            jnp.linspace(0.0, self.plan_horizon, self.num_knots) + state.time
+        )
+        clamped_tk = jnp.clip(new_tk, tk[0], tk[-1])
+        new_best = self.interp_func(
+            clamped_tk, tk, params.best_knots[None, ...]
+        )[0]
+        params = params.replace(best_knots=new_best)
+        return super().optimize(state, params)
 
     def _interp_paths(self, paths: jax.Array) -> jax.Array:
         """Smooth tensor paths into ``(B, num_knots, nu)`` knot tensors."""

--- a/hydrax/models/particle_navigation/particle.xml
+++ b/hydrax/models/particle_navigation/particle.xml
@@ -1,0 +1,60 @@
+<mujoco model="particle">
+  <!-- Adopted from the MJPC particle task:
+    https://github.com/google-deepmind/mujoco_mpc/tree/main/mjpc/tasks/particle
+  -->
+  <!-- Contacts are enabled so the inner U-walls actually stop the particle.
+       The legacy MJPC particle.xml used `contact="disable"` because it
+       relied on the cost-only SDF, which lets aggressive samplers
+       (large MTP graphs, large MPPI noise) tunnel straight through walls.
+
+       For a planar point mass we only need pair (sphere, plane) contacts,
+       so we cull collisions via contype / conaffinity bitmasks:
+         pointmass : contype=1 conaffinity=2
+         walls     : contype=2 conaffinity=1
+         floor     : contype=2 conaffinity=1 (defined in scene.xml; default
+                     bitmask is 1/1 so it still collides with the pointmass)
+       This avoids any wall-wall pair tests during MJX broadphase. -->
+  <option timestep="0.01" iterations="2" ls_iterations="6">
+    <flag eulerdamp="disable"/>
+  </option>
+
+  <default>
+    <joint type="hinge" axis="0 0 1" limited="true" range="-.29 .29" damping="1" />
+    <motor gear=".1" ctrlrange="-1 1" ctrllimited="true" />
+    <default class="wall">
+      <geom type="box" contype="2" conaffinity="1" rgba="0.6 0.6 0.6 1"
+            friction="0.1 0.005 0.0001" solref="0.005 1" solimp="0.95 0.99 0.001"/>
+    </default>
+  </default>
+
+  <worldbody>
+    <body name="goal" mocap="true" pos="0.25 0 0.01" quat="1 0 0 0">
+      <geom type="sphere" size=".01" contype="0" conaffinity="0" rgba="0 1 0 .5" />
+    </body>
+
+    <camera name="top_view" pos="0 -0.635 0.635" xyaxes="1 0 0 0 0.7 0.7" />
+    <geom name="wall_x"     class="wall" pos="-.31  0   .02" size=".02 .3  .02" />
+    <geom name="wall_neg_x" class="wall" pos=" .31  0   .02" size=".02 .3  .02" />
+    <geom name="wall_y"     class="wall" pos=" 0  -.31  .02" size=".3  .02 .02" />
+    <geom name="wall_neg_y" class="wall" pos=" 0   .31  .02" size=".3  .02 .02" />
+
+    <geom name="wall_ix"     class="wall" pos=" .1  0   .02" size=".01 .11 .02" />
+    <geom name="wall_iy"     class="wall" pos=" 0  -.1  .02" size=".11 .01 .02" />
+    <geom name="wall_neg_iy" class="wall" pos=" 0   .1  .02" size=".11 .01 .02" />
+
+    <body name="pointmass" pos="0 0 .01">
+      <camera name="cam0" pos="0 -0.635 0.635" xyaxes="1 0 0 0 0.7 0.7" />
+      <joint name="root_x" type="slide" pos="0 0 0" axis="1 0 0" />
+      <joint name="root_y" type="slide" pos="0 0 0" axis="0 1 0" />
+      <geom name="pointmass" type="sphere" size=".01" mass=".3"
+            contype="1" conaffinity="2"
+            friction="0.1 0.005 0.0001" solref="0.005 1" solimp="0.95 0.99 0.001"/>
+      <site name="pointmass" pos="0 0 0" size="0.01" />
+    </body>
+  </worldbody>
+
+  <actuator>
+    <motor name="x_motor" joint="root_x" gear="1" ctrllimited="true" ctrlrange="-1 1" />
+    <motor name="y_motor" joint="root_y" gear="1" ctrllimited="true" ctrlrange="-1 1" />
+  </actuator>
+</mujoco>

--- a/hydrax/models/particle_navigation/scene.xml
+++ b/hydrax/models/particle_navigation/scene.xml
@@ -1,0 +1,23 @@
+<mujoco model="particle_scene">
+  <include file="particle.xml"/>
+
+  <statistic center="0 0 0" extent="0.9"/>
+
+  <visual>
+    <headlight diffuse="0.6 0.6 0.6" ambient="0.3 0.3 0.3" specular="0 0 0"/>
+    <rgba haze="0.15 0.25 0.35 1"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.3 0.5 0.7" rgb2="0 0 0" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.2 0.3 0.4" rgb2="0.1 0.2 0.3"
+      markrgb="0.8 0.8 0.8" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.2"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 1"/>
+    <geom name="floor" size="0 0 .125" type="plane" material="groundplane"/>
+  </worldbody>
+
+</mujoco>

--- a/hydrax/tasks/navigation.py
+++ b/hydrax/tasks/navigation.py
@@ -56,11 +56,12 @@ class Navigation(Task):
         # Box-SDF distance to each inner wall (signed, axis-aligned).
         pos = state.site_xpos[self.pointmass_id][None, :2]
         wall_dist = jnp.abs(pos - self._wall_pos) - self._wall_size
-        outside_dist = jnp.maximum(wall_dist, 1e-12)
+        outside_dist = jnp.maximum(wall_dist, 0.0)
         inside_dist = jnp.minimum(jnp.max(wall_dist, axis=-1), 0.0)
-        dist = (jnp.linalg.norm(outside_dist, axis=-1) + inside_dist).min(
-            axis=-1
-        )
+        dist = (
+            jnp.sqrt(jnp.sum(jnp.square(outside_dist), axis=-1) + 1e-12)
+            + inside_dist
+        ).min(axis=-1)
         wall_cost = 5.0 * jnp.exp(-50.0 * dist)
         control_cost = jnp.sum(jnp.square(control))
         return wall_cost + self.terminal_cost(state) + 0.1 * control_cost

--- a/hydrax/tasks/navigation.py
+++ b/hydrax/tasks/navigation.py
@@ -1,0 +1,93 @@
+"""Velocity-controlled point mass that must escape a U-shaped maze.
+
+The task is identical in dynamics to ``hydrax.tasks.particle.Particle`` but
+adds three inner walls forming a U around the start position. This creates
+a local minimum on the straight-line path to the goal that defeats most
+local samplers, providing a clean showcase for globally-exploratory
+controllers such as MTP.
+"""
+
+from typing import Dict
+
+import jax
+import jax.numpy as jnp
+import mujoco
+from mujoco import mjx
+
+from hydrax import ROOT
+from hydrax.task_base import Task
+
+
+class Navigation(Task):
+    """A planar point mass that must navigate around U-shaped inner walls."""
+
+    def __init__(self, impl: str = "jax") -> None:
+        """Load the MuJoCo model and set task parameters."""
+        mj_model = mujoco.MjModel.from_xml_path(
+            ROOT + "/models/particle_navigation/scene.xml"
+        )
+        super().__init__(mj_model, trace_sites=["pointmass"], impl=impl)
+
+        self.pointmass_id = mj_model.site("pointmass").id
+
+        # Start the particle behind the U-opening so the straight-line path
+        # to the goal goes through a wall.
+        self._initial_qpos = jnp.array([-0.2, 0.0])
+
+        # Cache the planar geometry of the three inner walls (wall_ix,
+        # wall_iy, wall_neg_iy) for the SDF-style cost term.
+        self._wall_pos = jnp.array(
+            [
+                mj_model.geom("wall_ix").pos[:2],
+                mj_model.geom("wall_iy").pos[:2],
+                mj_model.geom("wall_neg_iy").pos[:2],
+            ]
+        )
+        self._wall_size = jnp.array(
+            [
+                mj_model.geom("wall_ix").size[:2],
+                mj_model.geom("wall_iy").size[:2],
+                mj_model.geom("wall_neg_iy").size[:2],
+            ]
+        )
+
+    def running_cost(self, state: mjx.Data, control: jax.Array) -> jax.Array:
+        """The running cost ℓ(xₜ, uₜ): wall SDF + tracking + control."""
+        # Box-SDF distance to each inner wall (signed, axis-aligned).
+        pos = state.site_xpos[self.pointmass_id][None, :2]
+        wall_dist = jnp.abs(pos - self._wall_pos) - self._wall_size
+        outside_dist = jnp.maximum(wall_dist, 1e-12)
+        inside_dist = jnp.minimum(jnp.max(wall_dist, axis=-1), 0.0)
+        dist = (jnp.linalg.norm(outside_dist, axis=-1) + inside_dist).min(
+            axis=-1
+        )
+        wall_cost = 5.0 * jnp.exp(-50.0 * dist)
+        control_cost = jnp.sum(jnp.square(control))
+        return wall_cost + self.terminal_cost(state) + 0.1 * control_cost
+
+    def terminal_cost(self, state: mjx.Data) -> jax.Array:
+        """The terminal cost ϕ(x_T): position tracking + velocity reg."""
+        position_cost = jnp.sum(
+            jnp.square(state.site_xpos[self.pointmass_id] - state.mocap_pos[0])
+        )
+        velocity_cost = jnp.sum(jnp.square(state.qvel))
+        return 5.0 * position_cost + 0.1 * velocity_cost
+
+    def domain_randomize_model(self, rng: jax.Array) -> Dict[str, jax.Array]:
+        """Randomly perturb the actuator gains by ±10%."""
+        multiplier = jax.random.uniform(
+            rng,
+            self.model.actuator_gainprm[:, 0].shape,
+            minval=0.9,
+            maxval=1.1,
+        )
+        new_gains = self.model.actuator_gainprm[:, 0] * multiplier
+        new_gains = self.model.actuator_gainprm.at[:, 0].set(new_gains)
+        return {"actuator_gainprm": new_gains}
+
+    def domain_randomize_data(
+        self, data: mjx.Data, rng: jax.Array
+    ) -> Dict[str, jax.Array]:
+        """Randomly shift the measured particle position."""
+        shift = jax.random.uniform(rng, (2,), minval=-0.01, maxval=0.01)
+        return {"qpos": data.qpos + shift}

--- a/hydrax/utils/spline.py
+++ b/hydrax/utils/spline.py
@@ -4,7 +4,7 @@ from typing import Callable, Literal
 import jax
 import jax.numpy as jnp
 from interpax import interp1d
-from jax import vmap
+from jax import jit, vmap
 
 InterpMethodType = Literal["zero", "linear", "cubic"]
 InterpFuncType = Callable[[jax.Array, jax.Array, jax.Array], jax.Array]
@@ -69,3 +69,175 @@ def get_interp_func(method: InterpMethodType) -> InterpFuncType:
             "Expected one of ['zero', 'linear', 'cubic']."
         )
     return interp_func
+
+
+# ---------------------------------------------------------------------------
+# Akima and B-spline primitives used by the MTP controller.
+#
+# These live alongside the standard interp_* helpers so MTP can share the
+# spline module with every other algorithm. They are deliberately pure
+# functions (no closure over a controller instance) so they JIT-compile
+# once per shape and stay picklable for async use.
+# ---------------------------------------------------------------------------
+
+
+@jit
+def poly_akima(x: jax.Array, c: jax.Array) -> jax.Array:
+    """Compute modified-Akima cubic spline coefficients through waypoints.
+
+    Builds the per-segment cubic polynomial coefficients of a modified Akima
+    spline (Akima 1970, with the symmetric mean fallback for collinear
+    sections) through ``M`` waypoints in ``D`` dimensions. The returned
+    coefficients are evaluated by :func:`poly_interpolation`.
+
+    Args:
+        x: Knot positions, shape ``(M,)``. Must be uniformly spaced.
+        c: Waypoint values, shape ``(M, D)``.
+
+    Returns:
+        Polynomial coefficients of shape ``(M-1, 4, D)``. Segment ``i``
+        stores ``[d_i, c_i, b_i, a_i]`` so that the cubic on
+        ``[x[i], x[i+1])`` is ``d_i*t^3 + c_i*t^2 + b_i*t + a_i``.
+    """
+    dx = jnp.diff(x)
+    m_pts, dim = c.shape[0], c.shape[1]
+    n_seg = m_pts - 1
+
+    # Slopes between breakpoints, with a safe inverse spacing.
+    safe_dx = jnp.where(dx == 0, 1.0, dx)
+    dxr = jnp.where(dx == 0, 0.0, 1.0 / safe_dx)[:, None]
+    y_l, y_r = c[:-1], c[1:]
+    slopes = (y_r - y_l) * dxr
+
+    # M==2: the Akima padded-slope cascade reads uninitialised entries with
+    # only one real slope; fall back to a single linear segment with
+    # endpoint derivatives both equal to that slope.
+    if n_seg == 1:
+        dydx_l = slopes * dxr
+        dydx_r = slopes * dxr
+        ai = y_l
+        bi = dydx_l
+        ci = 3.0 * slopes - 2.0 * dydx_l - dydx_r
+        di = -2.0 * slopes + dydx_l + dydx_r
+        a = jnp.stack([di, ci, bi, ai], axis=-1)
+        scale = dxr[:, None] ** jnp.arange(4)[::-1]
+        a = a / scale
+        return jnp.moveaxis(a, -1, 1)
+
+    # Pad slope array with two boundary extrapolations on each side.
+    m = jnp.zeros((n_seg + 4, dim))
+    m = m.at[2 : 2 + n_seg].set(slopes)
+    m = m.at[1].set(2.0 * m[2] - m[3])
+    m = m.at[0].set(2.0 * m[1] - m[2])
+    m = m.at[-2].set(2.0 * m[-3] - m[-4])
+    m = m.at[-1].set(2.0 * m[-2] - m[-3])
+
+    # Akima derivative weights (modified form: symmetric mean fallback when
+    # both weights vanish, avoiding the original 0/0 division).
+    dm = jnp.abs(jnp.diff(m, axis=0))
+    pm = jnp.abs(m[1:] + m[:-1])
+    f1 = dm[2:] + 0.5 * pm[2:]
+    f2 = dm[:-2] + 0.5 * pm[:-2]
+    m2 = m[1:-2]
+    m3 = m[2:-1]
+    f12 = f1 + f2
+    nonzero = f12 > 1e-9 * jnp.max(jnp.abs(f12), initial=0.0)
+    dydx = jnp.where(
+        nonzero,
+        (f1 * m2 + f2 * m3) / jnp.where(nonzero, f12, 1.0),
+        0.5 * (m2 + m3),
+    )
+
+    dydx_l = dydx[:-1] * dxr
+    dydx_r = dydx[1:] * dxr
+    ai = y_l
+    bi = dydx_l
+    ci = 3.0 * slopes - 2.0 * dydx_l - dydx_r
+    di = -2.0 * slopes + dydx_l + dydx_r
+    a = jnp.stack([di, ci, bi, ai], axis=-1)
+
+    # Rescale coefficients for the actual segment spacing (dx != 1).
+    scale = dxr[:, None] ** jnp.arange(4)[::-1]
+    a = a / scale
+    return jnp.moveaxis(a, -1, 1)
+
+
+@partial(jit, static_argnames=("num_points",))
+def poly_interpolation(a: jax.Array, num_points: int = 5) -> jax.Array:
+    """Evaluate a batch of Akima spline segments at uniform query points.
+
+    Uses a single ``einsum`` with a precomputed Vandermonde matrix to
+    evaluate every segment of every batch element in parallel.
+
+    Args:
+        a: Polynomial coefficients of shape ``(B, M-1, 4, D)`` produced by
+           :func:`poly_akima` (batched along the first axis).
+        num_points: Number of evaluation points per segment.
+
+    Returns:
+        Interpolated values of shape ``(B, (M-1) * num_points, D)``.
+    """
+    b, n_seg, _, dim = a.shape
+    t = jnp.linspace(0.0, 1.0, num_points + 1)[:-1]
+    powers = jnp.arange(3, -1, -1)
+    t_powers = t[:, None] ** powers[None, :]
+    spline = jnp.einsum("bspd,tp->bstd", a, t_powers)
+    return spline.reshape(b, n_seg * num_points, dim)
+
+
+def compute_b_spline_matrix(
+    x: jax.Array, degree: int, num_points: int
+) -> jax.Array:
+    """Build the B-spline basis matrix on the valid parameter domain.
+
+    Constructs the Cox-de Boor basis matrix evaluated at ``num_points``
+    uniformly-spaced parameter values inside the *valid* B-spline domain
+    ``[x[degree], x[-degree-1]]``, so every row satisfies the partition
+    of unity. Multiplying ``(num_points, M)`` against ``(B, M, D)`` knot
+    samples then yields a clean batched einsum.
+
+    Args:
+        x: The knot vector, shape ``(M + degree + 1,)``.
+        degree: The B-spline degree (``>= 2``).
+        num_points: Number of evaluation points across the valid domain.
+
+    Returns:
+        Basis matrix of shape ``(num_points, M)`` whose rows sum to 1.
+    """
+    t_start = x[degree]
+    t_end = x[-degree - 1]
+    # Tiny inward shrink avoids the right-open ``< x[i+1]`` boundary at
+    # ``t == t_end`` that would otherwise fire two intervals at once.
+    eps = (t_end - t_start) * 1e-7
+    t_values = jnp.linspace(t_start, t_end - eps, num_points)
+
+    b = jnp.where(
+        (x[:-1] <= t_values[:, None]) & (t_values[:, None] < x[1:]),
+        1.0,
+        0.0,
+    )
+
+    for d in range(1, degree + 1):
+        left_d1, left_d2 = x[d:-1], x[: -d - 1]
+        b_left = jnp.where(
+            left_d1 > left_d2,
+            (
+                (t_values[:, None] - left_d2)
+                / jnp.where(left_d1 > left_d2, left_d1 - left_d2, 1.0)
+            )
+            * b[:, :-1],
+            0.0,
+        )
+        right_d1, right_d2 = x[d + 1 :], x[1:-d]
+        b_right = jnp.where(
+            right_d1 > right_d2,
+            (
+                (right_d1 - t_values[:, None])
+                / jnp.where(right_d1 > right_d2, right_d1 - right_d2, 1.0)
+            )
+            * b[:, 1:],
+            0.0,
+        )
+        b = b_left + b_right
+
+    return b

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -1,0 +1,152 @@
+import jax
+import jax.numpy as jnp
+import pytest
+from mujoco import mjx
+
+from hydrax.algs.mtp import MTP
+from hydrax.tasks.pendulum import Pendulum
+
+
+def test_open_loop() -> None:
+    """Use MTP for open-loop pendulum swingup."""
+    task = Pendulum()
+    opt = MTP(
+        task,
+        num_samples=32,
+        m_pts=3,
+        n_per_layer=50,
+        num_elites=4,
+        sigma_start=1.0,
+        sigma_min=0.1,
+        sigma_max=2.0,
+        beta=0.5,
+        alpha=0.5,
+        mtp_interpolation="akima",
+        plan_horizon=1.0,
+        spline_type="zero",
+        num_knots=11,
+    )
+    jit_opt = jax.jit(opt.optimize)
+
+    state = mjx.make_data(task.model)
+    params = opt.init_params()
+
+    for _ in range(100):
+        params, _ = jit_opt(state, params)
+
+    knots = params.mean[None]
+    tk = jnp.linspace(0.0, opt.plan_horizon, opt.num_knots)
+    tq = jnp.linspace(0.0, opt.plan_horizon - opt.dt, opt.ctrl_steps)
+    controls = opt.interp_func(tq, tk, knots)
+    _, final_rollout = jax.jit(opt.eval_rollouts)(
+        task.model, state, controls, knots
+    )
+
+    total_cost = jnp.sum(final_rollout.costs[0])
+    assert total_cost <= 9.0
+    assert jnp.all(params.cov >= opt.sigma_min)
+    assert jnp.all(params.cov <= opt.sigma_max)
+
+
+@pytest.mark.parametrize("mtp_interpolation", ["akima", "bspline", "linear"])
+@pytest.mark.parametrize("m_pts", [2, 3, 5])
+def test_sample_knots_shape(mtp_interpolation: str, m_pts: int) -> None:
+    """Knot sampler returns the right shape across interpolation/m_pts combos.
+
+    Args:
+        mtp_interpolation: Tensor-branch interpolation type to test.
+        m_pts: Number of tensor waypoints to test.
+    """
+    if mtp_interpolation == "bspline" and m_pts < 3:
+        pytest.skip("bspline requires m_pts >= degree + 1")
+
+    task = Pendulum()
+    num_samples = 16
+    num_knots = 11
+    opt = MTP(
+        task,
+        num_samples=num_samples,
+        m_pts=m_pts,
+        n_per_layer=20,
+        num_elites=4,
+        sigma_start=0.5,
+        sigma_min=0.1,
+        sigma_max=1.0,
+        beta=0.5,
+        mtp_interpolation=mtp_interpolation,
+        plan_horizon=1.0,
+        spline_type="zero",
+        num_knots=num_knots,
+    )
+    params = opt.init_params(seed=0)
+    knots, _ = opt.sample_knots(params)
+    assert knots.shape == (num_samples, num_knots, task.model.nu)
+
+
+def test_bspline_invalid_m_pts_raises() -> None:
+    """Constructing MTP with bspline + m_pts < degree+1 raises."""
+    task = Pendulum()
+    with pytest.raises(ValueError, match="degree"):
+        MTP(
+            task,
+            num_samples=16,
+            m_pts=2,
+            num_elites=2,
+            mtp_interpolation="bspline",
+            degree=2,
+            plan_horizon=1.0,
+            spline_type="zero",
+            num_knots=11,
+        )
+
+
+def test_num_elites_too_large_raises() -> None:
+    """Constructing MTP with num_elites >= num_samples raises."""
+    task = Pendulum()
+    with pytest.raises(ValueError, match="num_elites"):
+        MTP(
+            task,
+            num_samples=8,
+            num_elites=8,
+            plan_horizon=1.0,
+            spline_type="zero",
+            num_knots=11,
+        )
+
+
+@pytest.mark.parametrize("beta", [0.0, 1.0])
+def test_beta_extremes_keep_sample_count(beta: float) -> None:
+    """Beta in {0.0, 1.0} still produces exactly num_samples rollouts.
+
+    Args:
+        beta: Tensor/local mixing fraction to test.
+    """
+    task = Pendulum()
+    num_samples = 16
+    opt = MTP(
+        task,
+        num_samples=num_samples,
+        m_pts=3,
+        num_elites=4,
+        beta=beta,
+        plan_horizon=1.0,
+        spline_type="zero",
+        num_knots=11,
+    )
+    params = opt.init_params(seed=0)
+    knots, _ = opt.sample_knots(params)
+    assert knots.shape[0] == num_samples
+
+
+if __name__ == "__main__":
+    test_open_loop()
+    for interp in ["akima", "bspline", "linear"]:
+        for m in [2, 3, 5]:
+            if interp == "bspline" and m < 3:
+                continue
+            test_sample_knots_shape(interp, m)
+    test_bspline_invalid_m_pts_raises()
+    test_num_elites_too_large_raises()
+    for b in [0.0, 1.0]:
+        test_beta_extremes_keep_sample_count(b)
+    print("All MTP tests passed!")

--- a/tests/test_mtp_splines.py
+++ b/tests/test_mtp_splines.py
@@ -1,0 +1,72 @@
+import jax.numpy as jnp
+
+from hydrax.utils.spline import (
+    compute_b_spline_matrix,
+    poly_akima,
+    poly_interpolation,
+)
+
+
+def test_akima_passes_through_knots() -> None:
+    """Akima spline reproduces the waypoints at every knot."""
+    m_pts = 5
+    x = jnp.linspace(1.0, m_pts, m_pts)
+    rng_seed = 0
+    y = jnp.array(
+        [[0.0, 0.0], [1.0, -1.0], [0.5, 2.0], [2.0, 0.5], [1.5, -0.5]]
+    )
+    a = poly_akima(x, y)  # (m_pts - 1, 4, 2)
+
+    # Each segment evaluated at t=0 should reproduce the left waypoint.
+    left = a[:, 3, :]
+    assert jnp.allclose(left, y[:-1], atol=1e-6), (
+        f"Expected segment starts {y[:-1]}, got {left}; seed={rng_seed}"
+    )
+
+
+def test_akima_beats_linear_on_sin_wave() -> None:
+    """Akima fit of a smooth signal beats linear interpolation."""
+    m_pts = 9
+    x = jnp.linspace(1.0, m_pts, m_pts)
+    sample_t = jnp.linspace(0.0, 2.0 * jnp.pi, m_pts)
+    y = jnp.sin(sample_t)[:, None]
+
+    a = poly_akima(x, y)
+    fine = poly_interpolation(a[None, ...], num_points=20)[0, :, 0]
+
+    # Reference signal at the same fine times.
+    seg_t = jnp.linspace(0.0, 1.0, 20 + 1)[:-1]
+    fine_t = jnp.concatenate(
+        [
+            sample_t[i] + seg_t * (sample_t[i + 1] - sample_t[i])
+            for i in range(m_pts - 1)
+        ]
+    )
+    truth = jnp.sin(fine_t)
+    linear = jnp.interp(fine_t, sample_t, y[:, 0])
+
+    akima_mse = jnp.mean((fine - truth) ** 2)
+    linear_mse = jnp.mean((linear - truth) ** 2)
+    assert akima_mse < linear_mse, (
+        f"Akima MSE {akima_mse:.4f} should beat linear MSE {linear_mse:.4f}"
+    )
+
+
+def test_b_spline_matrix_partition_of_unity() -> None:
+    """Each row of the B-spline basis matrix sums to one."""
+    for degree, m_pts in [(2, 3), (2, 4), (3, 4), (3, 5)]:
+        knots = jnp.arange(m_pts + degree + 1, dtype=jnp.float32)
+        mat = compute_b_spline_matrix(knots, degree, num_points=20)
+        assert mat.shape == (20, m_pts)
+        row_sums = jnp.sum(mat, axis=1)
+        assert jnp.allclose(row_sums, 1.0, atol=1e-5), (
+            f"Partition of unity failed for degree={degree}, M={m_pts}: "
+            f"row sums {row_sums}"
+        )
+
+
+if __name__ == "__main__":
+    test_akima_passes_through_knots()
+    test_akima_beats_linear_on_sin_wave()
+    test_b_spline_matrix_partition_of_unity()
+    print("All MTP spline tests passed!")

--- a/tests/test_navigation.py
+++ b/tests/test_navigation.py
@@ -1,0 +1,36 @@
+import jax.numpy as jnp
+import pytest
+from mujoco import mjx
+
+from hydrax.tasks.navigation import Navigation
+
+
+@pytest.mark.parametrize("impl", ["jax", "warp"])
+def test_navigation(impl: str) -> None:
+    """Smoke-test the U-maze navigation task.
+
+    Args:
+        impl: Which backend implementation to use.
+    """
+    task = Navigation(impl=impl)
+    assert task.pointmass_id >= 0
+    assert task._wall_pos.shape == (3, 2)
+    assert task._wall_size.shape == (3, 2)
+
+    state = task.make_data()
+    state = state.replace(mocap_pos=jnp.array([[0.25, 0.0, 0.01]]))
+    assert isinstance(state, mjx.Data)
+    state = mjx.forward(task.model, state)
+
+    ell = task.running_cost(state, jnp.zeros(2))
+    assert ell.shape == ()
+    assert ell > 0.0
+
+    phi = task.terminal_cost(state)
+    assert phi.shape == ()
+    assert phi > 0.0
+
+
+if __name__ == "__main__":
+    test_navigation("jax")
+    test_navigation("warp")


### PR DESCRIPTION
This PR adds **Model Tensor Planning** (MTP) as a new sampling-based controller, together with a U-maze navigation task that showcases its global exploration capability.

**Paper:** [Model Tensor Planning](https://arxiv.org/abs/2505.01059) - Le, Nguyen, Vu, Carvalho, Peters, TMLR 2025

### What is MTP?

MTP injects structured global exploration into a CEM-style local update. At each planning step it:

1. Samples `β · num_samples` paths through an M-partite tensor graph, each path is M independent waypoints, smoothed by Akima, B-spline, or linear interpolation into a control trajectory.
2. Samples the remaining `(1 − β) · num_samples` from a local Gaussian around the current best plan.
3. Selects elites via `jax.lax.top_k` and updates the mean/variance with softmax-weighted, Bessel-corrected statistics.

This lets MTP escape local minima that defeat PS / MPPI / CEM (e.g., a wall between start and goal).

### Files

| File | Description |
|------|-------------|
| `hydrax/algs/mtp.py` | MTP controller - `MTP` class and `MTPParams` dataclass |
| `hydrax/utils/spline.py` | Akima cubic + B-spline basis matrix primitives (appended to existing module) |
| `hydrax/tasks/navigation.py` | U-maze navigation task (point mass with inner walls) |
| `hydrax/models/particle_navigation/` | MJCF assets for the navigation task |
| `examples/navigation.py` | Interactive demo - supports `ps`, `mppi`, `cem`, `mtp` subcommands |
| `tests/test_mtp.py` | Algorithm tests: open-loop optimisation, shape checks, edge cases |
| `tests/test_mtp_splines.py` | Spline tests: knot interpolation, Akima vs linear MSE, B-spline partition of unity |
| `tests/test_navigation.py` | Task smoke test (both `jax` and `warp` backends) |

### Design decisions

- **Spline functions live in `hydrax/utils/spline.py`** rather than a separate subpackage - keeps the module hierarchy flat and lets any future algorithm reuse them.
- **Tensor sampling is simplified:** instead of materialising an `(M, N, nu)` graph and gathering paths via random indices, we sample `(mtp_samples, M, nu)` directly from uniform. Mathematically identical when candidates per layer are i.i.d., saves one allocation + gather.
- **`nan_to_num` removed from softmax weights:** `jax.nn.softmax` is already logsumexp-stable; silencing NaN would hide upstream cost bugs. Consistent with every other Hydrax algorithm.
- **`best_knots` is warm-started** in an `optimize()` override - the base class only re-interpolates `mean` onto the new knot time grid; we also re-interpolate `best_knots` to prevent control discontinuities when `spline_type != "zero"`.
- **Parameter naming** uses `m_pts` / `n_per_layer` (PEP 8) instead of the paper's uppercase `M` / `N`.

### Usage

```python
from hydrax.algs import MTP
from hydrax.tasks.navigation import Navigation

task = Navigation()
ctrl = MTP(
    task,
    num_samples=64,
    m_pts=3,
    n_per_layer=50,
    beta=0.5,
    mtp_interpolation="akima",
    plan_horizon=0.5,
    spline_type="zero",
    num_knots=11,
)
