### PR TITLE
Add Model Tensor Planning (MTP) controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Available methods:
 | [DIAL-MPC](https://arxiv.org/abs/2409.15610) | MPPI with dual-loop, annealed sampling covariance. | [`hydrax.algs.DIAL`](hydrax/algs/dial.py) |
 | [Evosax](https://github.com/RobertTLange/evosax/) | Any of the 30+ evolution strategies implemented in `evosax`. Includes CMA-ES, differential evolution, and many more. | [`hydrax.algs.Evosax`](hydrax/algs.evosax.py) |
 | [MPPI-CMA](https://arxiv.org/pdf/2506.22087) | MPPI with an adaptive sampling distribution. | [`hydrax.algs.MppiCma`](hydrax/algs/mppi_cma.py) |
+| [MTP](https://arxiv.org/abs/2505.01059) | Mix structured tensor-sampled trajectories with a local CEM update for global exploration. | [`hydrax.algs.MTP`](hydrax/algs/mtp.py) |
 
 ## News
 

--- a/hydrax/algs/__init__.py
+++ b/hydrax/algs/__init__.py
@@ -3,6 +3,15 @@ from .dial import DIAL
 from .evosax import Evosax
 from .mppi import MPPI
 from .mppi_cma import MppiCma
+from .mtp import MTP
 from .predictive_sampling import PredictiveSampling
 
-__all__ = ["CEM", "MPPI", "PredictiveSampling", "Evosax", "DIAL", "MppiCma"]
+__all__ = [
+    "CEM",
+    "MPPI",
+    "MTP",
+    "PredictiveSampling",
+    "Evosax",
+    "DIAL",
+    "MppiCma",
+]

--- a/hydrax/algs/mtp.py
+++ b/hydrax/algs/mtp.py
@@ -1,0 +1,305 @@
+"""Model Tensor Planning (MTP) controller.
+
+Implements the sampling-based MPC framework of Le et al. 2025
+(arxiv 2505.01059), which generates globally-diverse trajectory
+candidates via structured tensor sampling over a randomised M-partite
+graph and mixes them with a local CEM-style distribution.
+"""
+
+from typing import Literal, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+from flax.struct import dataclass
+from mujoco import mjx
+
+from hydrax.alg_base import SamplingBasedController, SamplingParams, Trajectory
+from hydrax.risk import RiskStrategy
+from hydrax.task_base import Task
+from hydrax.utils.spline import (
+    compute_b_spline_matrix,
+    interp_akima,
+    interp_bspline,
+)
+
+MTPInterpolationType = Literal["akima", "bspline", "linear"]
+
+
+@dataclass
+class MTPParams(SamplingParams):
+    """Policy parameters for Model Tensor Planning.
+
+    Attributes:
+        tk: The knot times of the control spline.
+        mean: Mean of the local CEM knot distribution, μ = [u₀, ...].
+        rng: The pseudo-random number generator key.
+        cov: Diagonal standard deviation of the local CEM distribution.
+        best_knots: Best spline knots from the previous optimisation step.
+    """
+
+    cov: jax.Array
+    best_knots: jax.Array
+
+
+class MTP(SamplingBasedController):
+    """Model Tensor Planning sampling-based MPC.
+
+    MTP draws a fraction ``beta`` of the rollouts from a structured
+    M-partite tensor sampler (random paths through ``M`` waypoints with
+    ``N`` candidates each, smoothed by an Akima/B-spline/linear
+    interpolation) and the remaining rollouts from a local Gaussian
+    around the current mean. Elite rollouts update the local mean and
+    covariance with a CEM-style softmax weighting.
+    """
+
+    def __init__(
+        self,
+        task: Task,
+        num_samples: int,
+        m_pts: int = 3,
+        n_per_layer: int = 50,
+        degree: int = 2,
+        num_elites: int = 5,
+        sigma_start: float = 0.5,
+        sigma_min: float = 0.1,
+        sigma_max: float = 1.0,
+        temperature: float = 0.1,
+        beta: float = 0.1,
+        alpha: float = 0.5,
+        mtp_interpolation: MTPInterpolationType = "akima",
+        num_randomizations: int = 1,
+        risk_strategy: Optional[RiskStrategy] = None,
+        seed: int = 0,
+        plan_horizon: float = 1.0,
+        spline_type: Literal["zero", "linear", "cubic"] = "zero",
+        num_knots: int = 4,
+        iterations: int = 1,
+    ) -> None:
+        """Initialise the controller.
+
+        Args:
+            task: The dynamics and cost for the system we want to control.
+            num_samples: Total number of control sequences to evaluate per
+                iteration. Must be at least ``num_elites + 1`` (one slot is
+                always reserved for the previous best).
+            m_pts: Number of tensor waypoints (graph depth).
+            n_per_layer: Number of candidate values per waypoint
+                (graph width).
+            degree: B-spline degree, only consulted when
+                ``mtp_interpolation='bspline'``. Must be ``>= 2``.
+            num_elites: Number of elite rollouts kept per iteration.
+            sigma_start: Initial standard deviation of the local Gaussian.
+            sigma_min: Lower clip on the local standard deviation.
+            sigma_max: Upper clip on the local standard deviation. Also
+                used to derive a finite sampling range when actuator
+                bounds are infinite.
+            temperature: Softmax temperature λ used for elite weighting.
+            beta: Fraction of rollouts drawn from the tensor sampler. The
+                remainder are drawn from the local Gaussian.
+            alpha: CEM smoothing weight. ``alpha = 0`` applies the new
+                statistics in full; ``alpha = 1`` keeps the old ones.
+            mtp_interpolation: Smoothing applied to each tensor path
+                before it is used as a control sequence.
+            num_randomizations: The number of domain randomizations to use.
+            risk_strategy: How to combining costs from different
+                randomizations. Defaults to average cost.
+            seed: The random seed for domain randomization.
+            plan_horizon: The time horizon for the rollout in seconds.
+            spline_type: The type of spline used for control interpolation.
+                Defaults to "zero" (zero-order hold).
+            num_knots: The number of knots in the control spline.
+            iterations: The number of optimization iterations to perform.
+        """
+        if degree < 2:
+            raise ValueError(f"degree must be at least 2, got {degree}.")
+        if num_elites < 1:
+            raise ValueError(
+                f"num_elites must be at least 1, got {num_elites}."
+            )
+        if num_elites >= num_samples:
+            raise ValueError(
+                f"num_elites ({num_elites}) must be strictly less than "
+                f"num_samples ({num_samples})."
+            )
+        if mtp_interpolation == "bspline" and m_pts < degree + 1:
+            raise ValueError(
+                f"B-spline interpolation requires m_pts >= degree + 1 "
+                f"(got m_pts={m_pts}, degree={degree})."
+            )
+
+        super().__init__(
+            task,
+            num_randomizations=num_randomizations,
+            risk_strategy=risk_strategy,
+            seed=seed,
+            plan_horizon=plan_horizon,
+            spline_type=spline_type,
+            num_knots=num_knots,
+            iterations=iterations,
+        )
+
+        self.num_samples = num_samples
+        self.m_pts = m_pts
+        self.n_per_layer = n_per_layer
+        self.degree = degree
+        self.num_elites = num_elites
+        self.sigma_start = sigma_start
+        self.sigma_min = sigma_min
+        self.sigma_max = sigma_max
+        self.temperature = temperature
+        self.beta = beta
+        self.alpha = alpha
+        self.mtp_interpolation = mtp_interpolation
+
+        # Reserve one slot for the previous best, split the rest.
+        mtp_samples = int(round(num_samples * beta))
+        self.mtp_samples = min(max(mtp_samples, 0), num_samples - 1)
+        self.cem_samples = num_samples - self.mtp_samples - 1
+
+        # Pre-compute interpolation parameters.
+        self._akima_tk = jnp.linspace(0.0, 1.0, m_pts)
+        self._akima_tq = jnp.linspace(0.0, 1.0, num_knots)
+        bknots = jnp.arange(m_pts + degree + 1)
+        self._bmat = compute_b_spline_matrix(bknots, degree, num_knots)
+
+        # Linear: pre-compute interpolation matrix.
+        if m_pts > 1:
+            n_total = -(-num_knots // (m_pts - 1)) * (m_pts - 1)
+            t_lin = jnp.linspace(0.0, m_pts - 1, n_total + 1)[:-1]
+            i_idx = jnp.clip(jnp.floor(t_lin).astype(jnp.int32), 0, m_pts - 2)
+            s = t_lin - i_idx
+            cols = jnp.arange(m_pts)
+            self._linmat = jnp.where(
+                cols[None, :] == i_idx[:, None], 1.0 - s[:, None], 0.0
+            ) + jnp.where(cols[None, :] == i_idx[:, None] + 1, s[:, None], 0.0)
+        else:
+            self._linmat = jnp.ones((num_knots, 1))
+
+    def init_params(
+        self, initial_knots: Optional[jax.Array] = None, seed: int = 0
+    ) -> MTPParams:
+        """Initialise the policy parameters."""
+        _params = super().init_params(initial_knots, seed)
+        cov = jnp.full_like(_params.mean, self.sigma_start)
+        best_knots = jnp.zeros_like(_params.mean)
+        return MTPParams(
+            tk=_params.tk,
+            mean=_params.mean,
+            rng=_params.rng,
+            cov=cov,
+            best_knots=best_knots,
+        )
+
+    def optimize(
+        self, state: mjx.Data, params: MTPParams
+    ) -> Tuple[MTPParams, Trajectory]:
+        """Optimise, warm-starting both ``mean`` and ``best_knots``."""
+        tk = params.tk
+        new_tk = (
+            jnp.linspace(0.0, self.plan_horizon, self.num_knots) + state.time
+        )
+        clamped_tk = jnp.clip(new_tk, tk[0], tk[-1])
+        new_best = self.interp_func(
+            clamped_tk, tk, params.best_knots[None, ...]
+        )[0]
+        params = params.replace(best_knots=new_best)
+        return super().optimize(state, params)
+
+    def _interp_paths(self, paths: jax.Array) -> jax.Array:
+        """Smooth tensor paths into ``(B, num_knots, nu)`` knot tensors."""
+        if self.mtp_interpolation == "akima":
+            return interp_akima(self._akima_tq, self._akima_tk, paths)
+        if self.mtp_interpolation == "bspline":
+            return interp_bspline(self._bmat, paths)
+        if self.mtp_interpolation == "linear":
+            return interp_bspline(self._linmat, paths)[
+                :, : self.num_knots
+            ]
+        raise ValueError(
+            f"Invalid MTP interpolation: {self.mtp_interpolation}. "
+            "Expected one of ['akima', 'bspline', 'linear']."
+        )
+
+    def sample_knots(self, params: MTPParams) -> Tuple[jax.Array, MTPParams]:
+        """Sample control spline knots using tensor + local Gaussian mixing.
+
+        Each call returns exactly ``num_samples`` knot sequences:
+        the previous-best slot, ``mtp_samples`` tensor-sampled
+        sequences, and ``cem_samples`` local Gaussian perturbations
+        of the current mean.
+        """
+        rng = params.rng
+        nu = self.task.model.nu
+        best = params.best_knots[None, ...]  # (1, num_knots, nu)
+
+        if self.mtp_samples >= 1:
+            rng, tensor_rng = jax.random.split(rng)
+
+            # Substitute finite bounds for unbounded actuators (±inf).
+            k = 3.0
+            mean_lo = jnp.min(params.mean, axis=0) - k * self.sigma_max
+            mean_hi = jnp.max(params.mean, axis=0) + k * self.sigma_max
+            u_min = jnp.where(
+                jnp.isfinite(self.task.u_min), self.task.u_min, mean_lo
+            )
+            u_max = jnp.where(
+                jnp.isfinite(self.task.u_max), self.task.u_max, mean_hi
+            )
+
+            # Sample tensor paths directly (equivalent to M-partite
+            # graph traversal but avoids materialising the full graph).
+            paths = jax.random.uniform(
+                tensor_rng,
+                (self.mtp_samples, self.m_pts, nu),
+                minval=u_min,
+                maxval=u_max,
+            )
+            mtp_knots = self._interp_paths(paths)
+            all_knots = jnp.concatenate([best, mtp_knots], axis=0)
+        else:
+            all_knots = best
+
+        if self.cem_samples > 0:
+            rng, sample_rng = jax.random.split(rng)
+            noise = jax.random.normal(
+                sample_rng, (self.cem_samples, self.num_knots, nu)
+            )
+            cem_knots = params.mean + params.cov * noise
+            all_knots = jnp.concatenate([all_knots, cem_knots], axis=0)
+
+        return all_knots, params.replace(rng=rng)
+
+    def update_params(
+        self, params: MTPParams, rollouts: Trajectory
+    ) -> MTPParams:
+        """Refit the local Gaussian with weighted elite statistics."""
+        costs = jnp.sum(rollouts.costs, axis=1)  # (num_samples,)
+
+        # Top-K elite selection.
+        _, elite_idx = jax.lax.top_k(-costs, self.num_elites)
+        elite_knots = rollouts.knots[elite_idx]
+        elite_costs = costs[elite_idx]
+
+        # Softmax weighting with baseline subtraction for numerical stability.
+        baseline = jnp.min(elite_costs)
+        weights = jax.nn.softmax(
+            -(elite_costs - baseline) / self.temperature, axis=0
+        )
+
+        # Weighted mean and Bessel-corrected standard deviation.
+        mean = jnp.sum(weights[:, None, None] * elite_knots, axis=0)
+        var = jnp.sum(
+            weights[:, None, None] * (elite_knots - mean) ** 2, axis=0
+        )
+        bessel = 1.0 / jnp.maximum(1.0 - jnp.sum(weights**2), 1e-6)
+        cov = jnp.sqrt(var * bessel)
+        cov = jnp.clip(cov, self.sigma_min, self.sigma_max)
+
+        # Momentum smoothing: convex blend of old and new variance.
+        mean = mean + self.alpha * (params.mean - mean)
+        new_var = cov**2
+        old_var = params.cov**2
+        cov = jnp.sqrt(self.alpha * old_var + (1.0 - self.alpha) * new_var)
+
+        best_knots = rollouts.knots[elite_idx[0]]
+        return params.replace(mean=mean, cov=cov, best_knots=best_knots)

--- a/hydrax/algs/mtp.py
+++ b/hydrax/algs/mtp.py
@@ -33,7 +33,7 @@ class MTPParams(SamplingParams):
         tk: The knot times of the control spline.
         mean: Mean of the local CEM knot distribution, μ = [u₀, ...].
         rng: The pseudo-random number generator key.
-        cov: Diagonal standard deviation of the local CEM distribution.
+        cov: Diagonal variance (σ²) of the local CEM distribution.
         best_knots: Best spline knots from the previous optimisation step.
     """
 
@@ -180,7 +180,7 @@ class MTP(SamplingBasedController):
     ) -> MTPParams:
         """Initialise the policy parameters."""
         _params = super().init_params(initial_knots, seed)
-        cov = jnp.full_like(_params.mean, self.sigma_start)
+        cov = jnp.full_like(_params.mean, self.sigma_start**2)
         best_knots = jnp.zeros_like(_params.mean)
         return MTPParams(
             tk=_params.tk,
@@ -264,7 +264,7 @@ class MTP(SamplingBasedController):
             noise = jax.random.normal(
                 sample_rng, (self.cem_samples, self.num_knots, nu)
             )
-            cem_knots = params.mean + params.cov * noise
+            cem_knots = params.mean + jnp.sqrt(params.cov) * noise
             all_knots = jnp.concatenate([all_knots, cem_knots], axis=0)
 
         return all_knots, params.replace(rng=rng)
@@ -280,26 +280,22 @@ class MTP(SamplingBasedController):
         elite_knots = rollouts.knots[elite_idx]
         elite_costs = costs[elite_idx]
 
-        # Softmax weighting with baseline subtraction for numerical stability.
-        baseline = jnp.min(elite_costs)
         weights = jax.nn.softmax(
-            -(elite_costs - baseline) / self.temperature, axis=0
+            -elite_costs / self.temperature, axis=0
         )
 
-        # Weighted mean and Bessel-corrected standard deviation.
+        # Weighted mean and Bessel-corrected variance.
         mean = jnp.sum(weights[:, None, None] * elite_knots, axis=0)
         var = jnp.sum(
             weights[:, None, None] * (elite_knots - mean) ** 2, axis=0
         )
         bessel = 1.0 / jnp.maximum(1.0 - jnp.sum(weights**2), 1e-6)
-        cov = jnp.sqrt(var * bessel)
-        cov = jnp.clip(cov, self.sigma_min, self.sigma_max)
+        cov = var * bessel
 
         # Momentum smoothing: convex blend of old and new variance.
         mean = mean + self.alpha * (params.mean - mean)
-        new_var = cov**2
-        old_var = params.cov**2
-        cov = jnp.sqrt(self.alpha * old_var + (1.0 - self.alpha) * new_var)
+        cov = self.alpha * params.cov + (1.0 - self.alpha) * cov
+        cov = jnp.clip(cov, self.sigma_min**2, self.sigma_max**2)
 
         best_knots = rollouts.knots[elite_idx[0]]
         return params.replace(mean=mean, cov=cov, best_knots=best_knots)

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -1,0 +1,143 @@
+import jax
+import jax.numpy as jnp
+import pytest
+from mujoco import mjx
+
+from hydrax.algs.mtp import MTP
+from hydrax.tasks.pendulum import Pendulum
+
+
+def test_open_loop() -> None:
+    """Use MTP for open-loop pendulum swingup."""
+    task = Pendulum()
+    opt = MTP(
+        task,
+        num_samples=32,
+        m_pts=3,
+        n_per_layer=50,
+        num_elites=4,
+        sigma_start=1.0,
+        sigma_min=0.1,
+        sigma_max=2.0,
+        beta=0.5,
+        alpha=0.5,
+        mtp_interpolation="akima",
+        plan_horizon=1.0,
+        spline_type="zero",
+        num_knots=11,
+    )
+    jit_opt = jax.jit(opt.optimize)
+
+    state = mjx.make_data(task.model)
+    params = opt.init_params()
+
+    for _ in range(100):
+        params, _ = jit_opt(state, params)
+
+    knots = params.mean[None]
+    tk = jnp.linspace(0.0, opt.plan_horizon, opt.num_knots)
+    tq = jnp.linspace(0.0, opt.plan_horizon - opt.dt, opt.ctrl_steps)
+    controls = opt.interp_func(tq, tk, knots)
+    _, final_rollout = jax.jit(opt.eval_rollouts)(
+        task.model, state, controls, knots
+    )
+
+    total_cost = jnp.sum(final_rollout.costs[0])
+    assert total_cost <= 9.0
+    assert jnp.all(params.cov >= opt.sigma_min)
+    assert jnp.all(params.cov <= opt.sigma_max)
+
+
+@pytest.mark.parametrize("mtp_interpolation", ["akima", "bspline", "linear"])
+@pytest.mark.parametrize("m_pts", [2, 3, 5])
+def test_sample_knots_shape(mtp_interpolation: str, m_pts: int) -> None:
+    """Knot sampler returns the right shape across interpolation/m_pts combos."""
+    if mtp_interpolation == "bspline" and m_pts < 3:
+        pytest.skip("bspline requires m_pts >= degree + 1")
+
+    task = Pendulum()
+    num_samples = 16
+    num_knots = 11
+    opt = MTP(
+        task,
+        num_samples=num_samples,
+        m_pts=m_pts,
+        n_per_layer=20,
+        num_elites=4,
+        sigma_start=0.5,
+        sigma_min=0.1,
+        sigma_max=1.0,
+        beta=0.5,
+        mtp_interpolation=mtp_interpolation,
+        plan_horizon=1.0,
+        spline_type="zero",
+        num_knots=num_knots,
+    )
+    params = opt.init_params(seed=0)
+    knots, _ = opt.sample_knots(params)
+    assert knots.shape == (num_samples, num_knots, task.model.nu)
+
+
+def test_bspline_invalid_m_pts_raises() -> None:
+    """Constructing MTP with bspline + m_pts < degree+1 raises."""
+    task = Pendulum()
+    with pytest.raises(ValueError, match="degree"):
+        MTP(
+            task,
+            num_samples=16,
+            m_pts=2,
+            num_elites=2,
+            mtp_interpolation="bspline",
+            degree=2,
+            plan_horizon=1.0,
+            spline_type="zero",
+            num_knots=11,
+        )
+
+
+def test_num_elites_too_large_raises() -> None:
+    """Constructing MTP with num_elites >= num_samples raises."""
+    task = Pendulum()
+    with pytest.raises(ValueError, match="num_elites"):
+        MTP(
+            task,
+            num_samples=8,
+            num_elites=8,
+            plan_horizon=1.0,
+            spline_type="zero",
+            num_knots=11,
+        )
+
+
+@pytest.mark.parametrize("beta", [0.0, 1.0])
+def test_beta_extremes_keep_sample_count(beta: float) -> None:
+    """Beta in {0.0, 1.0} still produces exactly num_samples rollouts."""
+    task = Pendulum()
+    num_samples = 16
+    opt = MTP(
+        task,
+        num_samples=num_samples,
+        m_pts=3,
+        num_elites=4,
+        beta=beta,
+        plan_horizon=1.0,
+        spline_type="zero",
+        num_knots=11,
+    )
+    params = opt.init_params(seed=0)
+    knots, _ = opt.sample_knots(params)
+    assert knots.shape[0] == num_samples
+
+
+if __name__ == "__main__":
+    test_open_loop()
+    for interp in ["akima", "bspline", "linear"]:
+        for m in [2, 3, 5]:
+            if interp == "bspline" and m < 3:
+                continue
+            test_sample_knots_shape(interp, m)
+    test_bspline_invalid_m_pts_raises()
+    test_num_elites_too_large_raises()
+    for b in [0.0, 1.0]:
+        test_beta_extremes_keep_sample_count(b)
+    print("All MTP tests passed!")

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -44,8 +44,8 @@ def test_open_loop() -> None:
 
     total_cost = jnp.sum(final_rollout.costs[0])
     assert total_cost <= 9.0
-    assert jnp.all(params.cov >= opt.sigma_min)
-    assert jnp.all(params.cov <= opt.sigma_max)
+    assert jnp.all(params.cov >= opt.sigma_min**2)
+    assert jnp.all(params.cov <= opt.sigma_max**2)
 
 
 @pytest.mark.parametrize("mtp_interpolation", ["akima", "bspline", "linear"])


### PR DESCRIPTION
Add the MTP sampling-based MPC controller (Le et al. 2025, arxiv 2505.01059).

MTP mixes two sampling strategies:
- **Tensor branch**: draws trajectories by uniformly sampling M waypoints within actuator bounds, then smoothing via Akima, B-spline, or linear interpolation (using the spline primitives from #74).
- **Local branch**: CEM-style Gaussian perturbations around the current mean, with softmax-weighted elite updates and momentum smoothing.

The `beta` parameter controls the tensor/local split. One slot is always reserved for the previous-best trajectory as a warm start.

### Files

- `hydrax/algs/mtp.py` - controller implementation
- `tests/test_mtp.py` - open-loop pendulum swingup, shape checks across all interpolation modes, validation guards
- `hydrax/algs/__init__.py` - export `MTP`
- `README.md` - add MTP to methods table

Depends on #74 (merged).
